### PR TITLE
fix(vacuum): status.state & battery-level stay empty on models that omit core services in the poll (e.g. r95475)

### DIFF
--- a/main.js
+++ b/main.js
@@ -557,10 +557,20 @@ class Dreame extends utils.Adapter {
           await this.loadMowerSettings(device);
         }
       }
+      // Seed status.state / status.battery-level from the device-list summary
+      // BEFORE the property poll runs, so that on models whose get_properties
+      // poll returns the core services (siid 2 = state, siid 3 = battery) the
+      // poll value wins (it runs afterwards and overwrites). On models that do
+      // not return them (e.g. dreame.vacuum.r95475) the summary value stays as
+      // the baseline. specPropsToIdDict is already populated by createRemotes.
+      for (const device of this.deviceArray) {
+        await this._bridgeStatusSummary(device);
+      }
       await this.updateDevicesViaSpec();
       await this.connectMqtt();
       this.updateInterval = setInterval(
         async () => {
+          await this.updateDeviceStatusSummary();
           await this.updateDevicesViaSpec();
         },
         this.config.interval * 60 * 1000,
@@ -867,6 +877,48 @@ class Dreame extends utils.Adapter {
         this.log.error('Device list error: ' + error);
         error.response && this.log.error('Device list error response: ' + JSON.stringify(error.response.data));
         this.log.error(error.stack);
+      });
+  }
+
+  // Mirror the device-list summary (latestStatus code + battery %) into
+  // status.state / status.battery-level. Newer vacuum models (e.g.
+  // dreame.vacuum.r95475) do not return the core services (siid 2 = robot
+  // state, siid 3 = battery) via the periodic get_properties poll — those only
+  // arrive via MQTT when they change, so the states would stay null while the
+  // robot is idle. The listV2 device summary always carries the current
+  // values, so mirror them as a baseline (an actual poll/MQTT value overwrites
+  // this because the poll runs afterwards / MQTT is realtime).
+  async _bridgeStatusSummary(record) {
+    if (!record || this.isMower(record)) return;
+    const did = String(record.did);
+    if (record.latestStatus != null) {
+      await this._lazyCreateState(did, 2, 1, record.latestStatus);
+    }
+    if (record.battery != null) {
+      await this._lazyCreateState(did, 3, 1, record.battery);
+    }
+  }
+
+  async updateDeviceStatusSummary() {
+    await this.requestClient({
+      method: 'post',
+      maxBodyLength: Infinity,
+      url: `https://${this.brand.domain}/dreame-user-iot/iotuserbind/device/listV2`,
+      headers: this.getHeaders(),
+      data: { sharedStatus: 1, current: 1, size: 100, lang: 'de', timestamp: Date.now() },
+    })
+      .then(async (response) => {
+        const records =
+          response && response.data && response.data.data && response.data.data.page
+            ? response.data.data.page.records
+            : null;
+        if (!Array.isArray(records)) return;
+        for (const record of records) {
+          await this._bridgeStatusSummary(record);
+        }
+      })
+      .catch((error) => {
+        this.log.debug('updateDeviceStatusSummary failed: ' + (error && error.message));
       });
   }
 


### PR DESCRIPTION
## Problem

On a Dreame Aqua10 Ultra (`dreame.vacuum.r95475`) the core status states stay empty while the robot is idle or right after adapter start:

- `status.state`, `status.battery-level`, `status.charging-status`, `status.task-status`, `status.cleaned-area`, `status.cleaning-time` → all `null`

They *do* fill in during an active cleaning run, but `status.battery-level` never appears at all.

## Root cause

For this model the periodic `get_properties` poll (`updateDevicesViaSpec`) does not return the core services — siid 2 (robot state), 3 (battery), 4 (cleaning status/progress/area/time). The top-level response is `code: 0` (no *"Error getting spec update"* in the log), consumables and higher services populate fine, but the core-service properties come back without a value, so `_lazyCreateState`'s `value != null` guard leaves the states empty.

Those values arrive instead via MQTT `properties_changed` when they change — which is why they appear during cleaning (state/area/time push as they change) but `battery-level` (siid 3, not pushed on a short run) and the idle state never show up.

The addresses are already correct — `lib/specs/core.js` maps `state` = 2-1, `battery-level` = 3-1, which match exactly what the device reports. It is purely that this model doesn't answer those services in the poll.

## Fix

The `device/listV2` summary that `getDeviceList()` already fetches carries the current `latestStatus` (same code space as siid 2-1 — it is decoded via `DEVICE_STATUS_STATES.vacuum`, which is also what `status.state` uses) and `battery`. This PR mirrors them into `status.state` / `status.battery-level` through the existing `_lazyCreateState` path:

- new `_bridgeStatusSummary(record)` — vacuum-only, writes 2-1 / 3-1 from the record
- new `updateDeviceStatusSummary()` — a light `listV2` fetch that bridges each record
- seeded at startup (after `createRemotes`, so `specPropsToIdDict` is populated) and once per poll interval

The bridge runs **before** `updateDevicesViaSpec` (both at startup and in the interval), so on models whose poll *does* return siid 2/3 the poll value overwrites the summary and stays authoritative — this only fills the gap where the poll leaves those states empty. MQTT stays authoritative during operation.

## Trade-off / open for discussion

- It adds one extra `listV2` request per poll interval (needed to keep `battery-level` fresh, since siid 3 isn't pushed via MQTT for this model). Happy to gate it behind a "poll didn't provide the core services" check if you'd rather avoid the extra call on models that don't need it.
- Scope kept to state + battery; shortcuts (4-48, currently mower-only) left out to keep this focused.

## Testing

Verified live on `dreame.vacuum.r95475` (v0.3.24 + this patch):

- adapter boots cleanly, no exceptions
- `status.battery-level` → `100` while idle (was `null` before; MQTT never pushes siid 3 and the poll returns nothing, so this can only come from the bridge)
- `status.state` matches `general.latestStatus` and the live MQTT value (`35` = dust-bag-drying while docked, `1` = cleaning during a run)

I only have this one model to test on. The before-poll ordering is meant to make this a no-op wherever the poll already works, but a second pair of eyes on that assumption would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)