### PR TITLE
fix: resolve vacuum state type warnings (siid 28 + auto-dust-collecting) and missing map objects

### DIFF
--- a/lib/specs/auto-empty.js
+++ b/lib/specs/auto-empty.js
@@ -8,7 +8,7 @@ module.exports = {
     { id: 'auto-empty-status', siid: 15, piid: 5, nameKey: 'vacuum.status.auto-empty-status', type: 'number', role: 'value' },
   ],
   remoteStates: [
-    { id: 'auto-dust-collecting',  siid: 15, piid: 1, nameKey: 'vacuum.remote.auto-dust-collecting',  type: 'boolean', role: 'switch' },
+    { id: 'auto-dust-collecting',  siid: 15, piid: 1, nameKey: 'vacuum.remote.auto-dust-collecting',  type: 'number',  role: 'level' },
     { id: 'auto-empty-frequency',  siid: 15, piid: 2, nameKey: 'vacuum.remote.auto-empty-frequency',  type: 'number',  role: 'level' },
   ],
 };

--- a/lib/specs/extended-settings.js
+++ b/lib/specs/extended-settings.js
@@ -19,7 +19,7 @@ module.exports = {
   remoteStates: [
     { id: 'wetness-level',         siid: 28, piid: 1,  nameKey: 'vacuum.remote.wetness-level',         type: 'number',  role: 'level', min: 1, max: 32 },
     { id: 'clean-carpets-first',   siid: 28, piid: 2,  nameKey: 'vacuum.remote.clean-carpets-first',   type: 'boolean', role: 'switch' },
-    { id: 'auto-lds-coverage',     siid: 28, piid: 3,  nameKey: 'vacuum.remote.auto-lds-coverage',     type: 'boolean', role: 'switch' },
+    { id: 'auto-lds-coverage',     siid: 28, piid: 3,  nameKey: 'vacuum.remote.auto-lds-coverage',     type: 'number',  role: 'level' },
     {
       id: 'cleangenius-mode',
       siid: 28,

--- a/lib/specs/extended-settings.js
+++ b/lib/specs/extended-settings.js
@@ -18,7 +18,7 @@ module.exports = {
   ],
   remoteStates: [
     { id: 'wetness-level',         siid: 28, piid: 1,  nameKey: 'vacuum.remote.wetness-level',         type: 'number',  role: 'level', min: 1, max: 32 },
-    { id: 'clean-carpets-first',   siid: 28, piid: 2,  nameKey: 'vacuum.remote.clean-carpets-first',   type: 'boolean', role: 'switch' },
+    { id: 'clean-carpets-first',   siid: 28, piid: 2,  nameKey: 'vacuum.remote.clean-carpets-first',   type: 'number',  role: 'level' },
     { id: 'auto-lds-coverage',     siid: 28, piid: 3,  nameKey: 'vacuum.remote.auto-lds-coverage',     type: 'number',  role: 'level' },
     {
       id: 'cleangenius-mode',
@@ -38,8 +38,8 @@ module.exports = {
       role: 'level',
       stateKeys: { 0: 'vacuum.water-temperature.cold', 1: 'vacuum.water-temperature.warm', 2: 'vacuum.water-temperature.hot', 3: 'vacuum.water-temperature.boiling' },
     },
-    { id: 'silent-drying',           siid: 28, piid: 27, nameKey: 'vacuum.remote.silent-drying',           type: 'boolean', role: 'switch' },
-    { id: 'hair-compression',        siid: 28, piid: 28, nameKey: 'vacuum.remote.hair-compression',        type: 'boolean', role: 'switch' },
-    { id: 'mopping-with-detergent',  siid: 28, piid: 52, nameKey: 'vacuum.remote.mopping-with-detergent',  type: 'boolean', role: 'switch' },
+    { id: 'silent-drying',           siid: 28, piid: 27, nameKey: 'vacuum.remote.silent-drying',           type: 'number',  role: 'level' },
+    { id: 'hair-compression',        siid: 28, piid: 28, nameKey: 'vacuum.remote.hair-compression',        type: 'number',  role: 'level' },
+    { id: 'mopping-with-detergent',  siid: 28, piid: 52, nameKey: 'vacuum.remote.mopping-with-detergent',  type: 'number',  role: 'level' },
   ],
 };

--- a/main.js
+++ b/main.js
@@ -4189,7 +4189,7 @@ class Dreame extends utils.Adapter {
       if (Object.prototype.toString.call(value) !== '[object Object]') {
         if (value != null) {
           const pathMap = In_path + key;
-          this.getType(value, pathMap);
+          await this.getType(value, pathMap);
           if (typeof value === 'object' && value !== null) {
             this.setState(pathMap, JSON.stringify(value), true);
           } else {
@@ -4249,27 +4249,27 @@ class Dreame extends utils.Adapter {
                       //1: DreameLevel, 2: DreameWaterVolume, 3: DreameRepeat, 4: DreameRoomNumber, 5: DreameCleaningMode, 6: Route
                       //map-req[{"piid": 2,"value": "{\"req_type\":1,\"frame_type\":I,\"force_type\":1}"}]
                       let pathMap = In_path + key + '.' + Subkey + '.RoomSettings';
-                      this.getType(JSON.stringify(Subvalue), pathMap);
+                      await this.getType(JSON.stringify(Subvalue), pathMap);
                       this.setState(pathMap, JSON.stringify(Subvalue), true);
                       pathMap = In_path + key + '.' + Subkey + '.RoomOrder';
-                      this.getType(parseFloat(Subvalue[3]), pathMap);
+                      await this.getType(parseFloat(Subvalue[3]), pathMap);
                       this.setState(pathMap, parseFloat(Subvalue[3]), true);
                       if (!isMowerDevice) {
                         pathMap = In_path + key + '.' + Subkey + '.Level';
-                        this.setcleansetPath(pathMap, DreameLevel);
+                        await this.setcleansetPath(pathMap, DreameLevel);
                         this.setState(pathMap, Subvalue[0], true);
                         pathMap = In_path + key + '.' + Subkey + '.CleaningMode';
-                        this.setcleansetPath(pathMap, DreameCleaningMode);
+                        await this.setcleansetPath(pathMap, DreameCleaningMode);
                         this.setState(pathMap, Subvalue[4], true);
                         pathMap = In_path + key + '.' + Subkey + '.WaterVolume';
-                        this.setcleansetPath(pathMap, DreameWaterVolume);
+                        await this.setcleansetPath(pathMap, DreameWaterVolume);
                         this.setState(pathMap, Subvalue[1], true);
                       }
                       pathMap = In_path + key + '.' + Subkey + '.Repeat';
-                      this.setcleansetPath(pathMap, DreameRepeat);
+                      await this.setcleansetPath(pathMap, DreameRepeat);
                       this.setState(pathMap, Subvalue[2], true);
                       pathMap = In_path + key + '.' + Subkey + '.Route';
-                      this.setcleansetPath(pathMap, DreameRoute);
+                      await this.setcleansetPath(pathMap, DreameRoute);
                       this.setState(pathMap, Subvalue[5], true);
                       pathMap = In_path + key + '.' + Subkey + '.Cleaning';
                       await this.setcleansetPath(pathMap, DreameRoomClean);
@@ -4281,7 +4281,7 @@ class Dreame extends utils.Adapter {
                   }
                 }
               } else {
-                this.getType(Subvalue, pathMap);
+                await this.getType(Subvalue, pathMap);
                 this.setState(pathMap, JSON.stringify(Subvalue), true);
               }
             }

--- a/main.js
+++ b/main.js
@@ -2318,8 +2318,8 @@ class Dreame extends utils.Adapter {
         name: 'Auto Dust Collecting (15-1)',
         siid: 15,
         piid: 1,
-        type: 'boolean',
-        role: 'switch',
+        type: 'number',
+        role: 'level',
       },
       {
         id: 'auto-empty-frequency',
@@ -2339,7 +2339,7 @@ class Dreame extends utils.Adapter {
         type: 'boolean',
         role: 'switch',
       },
-      { id: 'auto-lds-coverage', name: 'Auto LDS Coverage (28-3)', siid: 28, piid: 3, type: 'boolean', role: 'switch' },
+      { id: 'auto-lds-coverage', name: 'Auto LDS Coverage (28-3)', siid: 28, piid: 3, type: 'number', role: 'level' },
       {
         id: 'cleangenius-mode',
         name: 'CleanGenius Mode (28-5)',

--- a/main.js
+++ b/main.js
@@ -2336,8 +2336,8 @@ class Dreame extends utils.Adapter {
         name: 'Clean Carpets First (28-2)',
         siid: 28,
         piid: 2,
-        type: 'boolean',
-        role: 'switch',
+        type: 'number',
+        role: 'level',
       },
       { id: 'auto-lds-coverage', name: 'Auto LDS Coverage (28-3)', siid: 28, piid: 3, type: 'number', role: 'level' },
       {
@@ -2358,15 +2358,15 @@ class Dreame extends utils.Adapter {
         role: 'level',
         states: { 0: 'Cold', 1: 'Warm', 2: 'Hot', 3: 'Boiling' },
       },
-      { id: 'silent-drying', name: 'Silent Drying (28-27)', siid: 28, piid: 27, type: 'boolean', role: 'switch' },
-      { id: 'hair-compression', name: 'Hair Compression (28-28)', siid: 28, piid: 28, type: 'boolean', role: 'switch' },
+      { id: 'silent-drying', name: 'Silent Drying (28-27)', siid: 28, piid: 27, type: 'number', role: 'level' },
+      { id: 'hair-compression', name: 'Hair Compression (28-28)', siid: 28, piid: 28, type: 'number', role: 'level' },
       {
         id: 'mopping-with-detergent',
         name: 'Mopping With Detergent (28-52)',
         siid: 28,
         piid: 52,
-        type: 'boolean',
-        role: 'switch',
+        type: 'number',
+        role: 'level',
       },
     ];
 


### PR DESCRIPTION
Two independent fixes for warnings seen on live devices.

## 1. Six settings are declared `boolean` but the device reports numbers

`_lazyCreateState()` converts a boolean-declared property only when the value is exactly 0 or 1. When a device reports anything else the value is dropped and ioBroker logs `has to be type "boolean" but received type "number"` on every update.

Affected, all retyped to `number` / `level`:

| address | id | reported by |
|---|---|---|
| 15-1 | `auto-dust-collecting` | r95475 (value `2`), and #82 |
| 28-3 | `auto-lds-coverage` | r95475 (value `2`), and #82 |
| 28-2 | `clean-carpets-first` | #82 |
| 28-27 | `silent-drying` | #82 |
| 28-28 | `hair-compression` | #82 |
| 28-52 | `mopping-with-detergent` | #82 |

**Why `number` is the correct declaration, not a workaround:**

- `auto-dust-collecting` (15-1) is the only one of the six that a published MIoT spec covers. 21 released `dreame.vacuum` models declare it `format: uint32` with `value-list [0=Close-auto-collect, 1=Open-auto-collect]` — an enum, which is `type:number` in ioBroker, never `type:boolean`. The boolean declaration was wrong from the start; a device reporting `2` merely exposed it.
- The other five are declared by **no** released `dreame.vacuum` spec (all 59 checked). Worth noting: `siid 28` on the older 1808 models is the `brush-cleaner` service, a different address space — so those are not counterexamples. There is no source declaring these as `bool` either; `boolean` is an assumption.
- On an r95475 the four newly added ones currently report 0/1, so they look like clean booleans there. That is consistent rather than contradictory: the declaration must cover the widest domain in the family, and `number` does while `boolean` silently loses everything outside 0/1.

Changed in `lib/specs/{extended-settings,auto-empty}.js` **and** in the inline `createVacuumRemotes` definitions — the inline meta would otherwise win. `role` moves with the type (`switch` → `level`).

This composes with the write-side fix in v0.3.25: that one sends 1/0 for states declared `boolean`, which would have clamped a legitimate value of `2` to `1`. With the corrected type the raw value is written through.

## 2. Map states are written before their objects exist

`setMapInfos()` calls the object-creating `getType()` / `setcleansetPath()` without `await` and then `setState()`s immediately, producing `has no existing object` for 18 `map.*` states. Nine calls now `await` (line 3879 was already awaited — same pattern, so this aligns the rest).

Verified on the resulting tree: `npm run lint` clean, `npm run check` unchanged at the 114-error baseline, `npm run test:js` green, and `buildVacuumLookup("dreame.vacuum.r95475")` resolves all six addresses to `number` with a non-`switch` role.

Addresses #82.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>