### PR TITLE
fix(#82): stream-status is a streaming-session object, not a number

### DIFF
--- a/lib/specs/camera.js
+++ b/lib/specs/camera.js
@@ -6,10 +6,14 @@
 // protocol control fields (stream_audio, take_photo, stream_keep_alive etc.)
 // — NOT stored as ioBroker states (internal protocol use only).
 // piid 1 (stream_status) is device-reported and exposed as a readable state.
+// Its payload is a streaming-session object, not a number — observed on
+// dreame.vacuum.r95475 (firmware 4.3.9_3665_release):
+//   {"operType":"end","operation":"monitor","result":0,"status":0}
+// _lazyCreateState() JSON.stringify()s it, hence type:string / role:json.
 
 module.exports = {
   statusStates: [
-    { id: 'stream-status',          siid: 10001, piid: 1, nameKey: 'vacuum.status.stream-status',          type: 'number', role: 'value' },
+    { id: 'stream-status',          siid: 10001, piid: 1, nameKey: 'vacuum.status.stream-status',          type: 'string', role: 'json' },
     { id: 'camera-light-brightness', siid: 10001, piid: 9, nameKey: 'vacuum.status.camera-light-brightness', type: 'string', role: 'text' },
   ],
   remoteStates: [],


### PR DESCRIPTION
The `stream-status` warning from #82 still fires after v0.3.25 on `dreame.vacuum.r95475`. v0.3.25 noted that the raw format could not be verified on a device — here it is, read off the live state:

```
{"operType":"end","operation":"monitor","result":0,"status":0}
```

`stream-status` (10001-1) is not a number at all. It is a streaming-session object describing the camera monitor session, so it never matches the `/^-?\d+$/` guard the v0.3.25 conversion uses. `_lazyCreateState()` `JSON.stringify()`s the object and writes a string into a state declared as `type:number` — hence the warning on every update.

So this fixes the declaration rather than the value: `type:string` / `role:json`, the convention this repo already uses for structured payloads (`dnd-task` 5-4, `task-info` 2-50, `zone-status` 2-56, `self-check` 2-58). That also covers the numeric-string case, since a numeric string is still a string.

The numeric-string conversion added in v0.3.25 is deliberately left in place — it is generic and still applies to other number-typed properties.

Existing installations heal themselves: `_lazyCreateState()` calls `extendObject()` on the first write after a restart, which updates `common.type`. No migration needed.

**Device:** `dreame.vacuum.r95475`, firmware `4.3.9_3665_release`, adapter 0.3.25.

**Verified:** `buildVacuumLookup("dreame.vacuum.r95475")` resolves `10001-1` to `{type:"string", role:"json"}`; `npm run lint` clean; `npm run check` unchanged at the 114-error baseline; `npm run test:js` green.

Addresses #82.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>