### PR TITLE
feat(shortcuts): expose app shortcuts on vacuums, not just mowers

### DIFF
--- a/lib/shortcuts.js
+++ b/lib/shortcuts.js
@@ -1,0 +1,47 @@
+'use strict';
+
+// Parsing of the shortcut list reported on siid 4 / piid 48.
+//
+// Kept free of adapter state on purpose: the guard that decides whether a
+// device has shortcuts at all lives here, so it can be unit tested. Both
+// vacuums and mowers report the same structure; devices that use 4-48 for
+// something else yield an empty list and therefore create no objects.
+
+/**
+ * Turn a raw 4-48 value into a list of shortcut entries.
+ *
+ * @param {*} value raw property value (JSON string or already parsed)
+ * @returns {{id: (string|number), name: string}[]}
+ *   one entry per usable shortcut; empty if the value is not a shortcut list
+ */
+function parseShortcutList(value) {
+  let shortcuts;
+  try {
+    shortcuts = typeof value === 'string' ? JSON.parse(value) : value;
+  } catch {
+    return [];
+  }
+  // Only a list of entries is a shortcut list. Some models report an unrelated
+  // scalar on 4-48 (the MIoT spec declares it as a plain uint32 on several
+  // released models), so anything that is not an array is not ours.
+  if (!Array.isArray(shortcuts)) return [];
+
+  const result = [];
+  for (const sc of shortcuts) {
+    if (!sc || sc.id === undefined || typeof sc.name !== 'string') continue;
+    let name;
+    try {
+      name = Buffer.from(sc.name, 'base64').toString('utf-8');
+    } catch {
+      continue;
+    }
+    if (!name) continue;
+    // No running flag: the device reports sc.state only as a transient pulse when a
+    // shortcut is triggered and never signals the end, so it cannot back a truthful
+    // indicator. The caller exposes name + start button only.
+    result.push({ id: sc.id, name });
+  }
+  return result;
+}
+
+module.exports = { parseShortcutList };

--- a/main.js
+++ b/main.js
@@ -14,6 +14,7 @@ const Json2iob = require('json2iob');
 const crypto = require('node:crypto');
 const mqtt = require('mqtt');
 const zlib = require('node:zlib');
+const { parseShortcutList } = require('./lib/shortcuts');
 //check if canvas is available because is optional dependency
 let createCanvas;
 let ImageData;
@@ -2857,6 +2858,15 @@ class Dreame extends utils.Adapter {
       }
     }
 
+    // Shortcuts only arrive through MQTT (siid 4 does not answer get_properties),
+    // and the device pushes the list only when it changes. Without this the
+    // buttons would stay missing after a restart until that happens by chance,
+    // so rebuild them from the value already persisted in status.shortcuts.
+    const _scPersisted = await this.getStateAsync(`${did}.status.shortcuts`);
+    if (_scPersisted && _scPersisted.val) {
+      await this.parseShortcuts(did, _scPersisted.val);
+    }
+
     this.log.info(
       `Vacuum states created: ${statusStates.length} status, ${remoteStates.length} remote, ${autoSwitchRemotes.length} autoSwitch, ${actionStates.length} actions`,
     );
@@ -4026,9 +4036,13 @@ class Dreame extends utils.Adapter {
           if (this.isVacuum(device) && element.siid === 4 && element.piid === 50) {
             this.parseVacuumAutoSwitch(did, element.value);
           }
-          // Shortcuts (4-48): parse base64 names and running state
-          if (this.isMower(device) && element.siid === 4 && element.piid === 48) {
-            this.parseShortcuts(did, element.value);
+          // Shortcuts (4-48): parse base64 names and running state.
+          // Not restricted to mowers — vacuums report their app shortcuts on the
+          // same property and start them with the same action. parseShortcuts()
+          // ignores anything that is not a shortcut list, so devices that use
+          // 4-48 differently are unaffected.
+          if (element.siid === 4 && element.piid === 48) {
+            await this.parseShortcuts(did, element.value);
           }
           // Lazy create + setState für Properties mit bekannter Metadaten-Definition
           const lazyPath = await this._lazyCreateState(did, element.siid, element.piid, element.value);
@@ -5437,32 +5451,36 @@ class Dreame extends utils.Adapter {
     }
   }
 
-  parseShortcuts(did, value) {
+  async parseShortcuts(did, value) {
     try {
-      const shortcuts = typeof value === 'string' ? JSON.parse(value) : value;
-      if (!Array.isArray(shortcuts)) return;
-      for (const sc of shortcuts) {
-        const name = Buffer.from(sc.name, 'base64').toString('utf-8');
-        const running = sc.state === '0' || sc.state === '1';
+      for (const sc of parseShortcutList(value)) {
         const path = `${did}.shortcuts.${sc.id}`;
-        this.extendObject(path, { type: 'channel', common: { name: name }, native: {} });
-        this.extendObject(path + '.name', {
+        await this.extendObject(path, { type: 'channel', common: { name: sc.name }, native: {} });
+        await this.extendObject(path + '.name', {
           type: 'state',
           common: { name: 'Shortcut Name', type: 'string', role: 'text', read: true, write: false },
           native: {},
         });
-        this.setState(path + '.name', name, true);
-        this.extendObject(path + '.running', {
+        this.setState(path + '.name', sc.name, true);
+        // The device reports a shortcut's state only as a transient start pulse
+        // (state:"1" for a single push right after it is triggered, then gone) and
+        // never signals the end, so a per-shortcut running indicator cannot be kept
+        // truthful — an earlier version's `.running` stayed stuck at true. Remove it.
+        // delObject drops the leaf value too; safe here because this create path is
+        // sequential (no concurrent observer).
+        await this.delObjectAsync(path + '.running').catch(() => undefined);
+        await this.extendObject(path + '.start', {
           type: 'state',
-          common: { name: 'Running', type: 'boolean', role: 'indicator', read: true, write: false },
-          native: {},
-        });
-        this.setState(path + '.running', running, true);
-        this.extendObject(path + '.start', {
-          type: 'state',
-          common: { name: `Start "${name}"`, type: 'boolean', role: 'button', read: false, write: true },
+          common: { name: `Start "${sc.name}"`, type: 'boolean', role: 'button', read: false, write: true, def: false },
           native: { shortcutId: sc.id, did: did },
         });
+        // A button rests at false. Objects created before this fix had no default
+        // (value null), and a press left them stuck at true because the handler did
+        // not reset them. Normalise anything that is not already false.
+        const _scStart = await this.getStateAsync(path + '.start');
+        if (!_scStart || _scStart.val !== false) {
+          this.setState(path + '.start', false, true);
+        }
       }
     } catch (e) {
       this.log.debug(`parseShortcuts error: ${e.message}`);
@@ -5868,7 +5886,10 @@ class Dreame extends utils.Adapter {
           const stateObjSc = await this.getObjectAsync(id);
           if (stateObjSc && stateObjSc.native && stateObjSc.native.shortcutId !== undefined) {
             const device = this.deviceArray.find((obj) => obj.did === deviceId);
-            if (!device || !this.isMower(device)) return;
+            // No device-class check: this button only exists where parseShortcuts()
+            // created it, so reaching this point already means the device reported
+            // a shortcut list. Action 4-1 with mode 25 is the same on both classes.
+            if (!device) return;
             const scId = String(stateObjSc.native.shortcutId);
             this.log.info(`Starting shortcut ${scId} for ${device.model}`);
             await this.sendCommand({
@@ -5884,6 +5905,10 @@ class Dreame extends utils.Adapter {
                 ],
               },
             });
+            // Reset the button (role:button) after triggering, ack:true so this
+            // write does not re-enter onStateChange. Without it the pressed value
+            // stays true and the button reads as permanently "on".
+            await this.setState(id, false, true);
             return;
           }
         }

--- a/shortcuts.test.js
+++ b/shortcuts.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const { expect } = require('chai');
+const { parseShortcutList } = require('./lib/shortcuts');
+
+// Real payload read from status.shortcuts of a dreame.vacuum.r95475.
+const VACUUM_PAYLOAD =
+  '[{"id":32,"name":"V29obnppbW1lciAtIEVzc2Vu"},' +
+  '{"id":33,"name":"VMOkZ2xpY2ggLSBzYXVnZW4="},' +
+  '{"id":34,"name":"VMOkZ2xpY2ggLSBTJlc="}]';
+
+describe('parseShortcutList', () => {
+  it('decodes base64 names from a vacuum payload', () => {
+    const list = parseShortcutList(VACUUM_PAYLOAD);
+    expect(list).to.have.lengthOf(3);
+    expect(list.map((s) => s.id)).to.deep.equal([32, 33, 34]);
+    expect(list.map((s) => s.name)).to.deep.equal(['Wohnzimmer - Essen', 'Täglich - saugen', 'Täglich - S&W']);
+  });
+
+  it('ignores the transient state field — no running flag is derived', () => {
+    // The device reports state only as a short pulse when a shortcut is triggered
+    // and never signals the end, so it must not surface as a state.
+    const list = parseShortcutList([{ id: 1, name: Buffer.from('Kitchen').toString('base64'), state: '1' }]);
+    expect(list).to.deep.equal([{ id: 1, name: 'Kitchen' }]);
+  });
+
+  it('ignores values that are not a shortcut list', () => {
+    // Several released dreame.vacuum models declare 4-48 as a plain uint32.
+    // Such devices must not get shortcut objects.
+    expect(parseShortcutList('12345')).to.deep.equal([]);
+    expect(parseShortcutList(12345)).to.deep.equal([]);
+    expect(parseShortcutList('{"foo":1}')).to.deep.equal([]);
+    expect(parseShortcutList(null)).to.deep.equal([]);
+    expect(parseShortcutList(undefined)).to.deep.equal([]);
+  });
+
+  it('survives malformed JSON without throwing', () => {
+    expect(parseShortcutList('[{"id":1,')).to.deep.equal([]);
+  });
+
+  it('skips entries without a usable id or name', () => {
+    const list = parseShortcutList([
+      { id: 1, name: Buffer.from('ok').toString('base64') },
+      { name: Buffer.from('no id').toString('base64') },
+      { id: 3 },
+      { id: 4, name: 42 },
+      null,
+    ]);
+    expect(list).to.have.lengthOf(1);
+    expect(list[0].name).to.equal('ok');
+  });
+
+  it('accepts an already parsed array', () => {
+    const list = parseShortcutList([{ id: 9, name: Buffer.from('Küche').toString('base64') }]);
+    expect(list).to.deep.equal([{ id: 9, name: 'Küche' }]);
+  });
+});


### PR DESCRIPTION
## What this fixes

On a vacuum the app shortcuts (the quick commands you set up in the Dreame app) are unavailable: no buttons appear, and where a button does exist, pressing it does nothing. That has been the case since shortcuts were added — the feature was wired for mowers only.

## Why

v0.4.0 already ships a generic `parseShortcuts()`, but both the `4-48` parse call and the start handler are `isMower`-gated. A vacuum therefore never gets its shortcut list parsed, and even a manually created start button returns early.

Vacuums expose their shortcuts on the **same** property (siid 4 / piid 48) and start them with the **same** action (`4-1`, mode 25) — verified byte-identical against the REST calls a `dreame.vacuum.r95475` accepts.

## Changes

- **Gate on the data shape, not the device class.** `parseShortcutList()` returns `[]` for anything that is not a shortcut list, so the several released models that report `4-48` as a plain `uint32` create no objects. The start button is self-limiting — it only exists where `parseShortcutList()` created it.
- **Seed the buttons on startup** from the persisted `status.shortcuts`, since `4-48` only arrives over MQTT on change and would otherwise be missing after a restart until the next random push.
- **`parseShortcuts()` is async and awaits object creation before `setState`** — the previous fire-and-forget raced the "has no existing object" warning.
- **The start button resets to `false` after triggering** (ack) and defaults to `false`, so it no longer reads as permanently pressed.
- **No per-shortcut `running` indicator.** The device reports `sc.state` only as a transient pulse when a shortcut is triggered and never signals the end (confirmed on a `dreame.vacuum.r95475`: `state:"1"` shows up for a single push, then disappears), so it cannot back a truthful indicator. Any stale `.running` left by an earlier revision (stuck at `true`) is removed.

## Tests

New `lib/shortcuts.js` (`parseShortcutList`) as a unit-testable seam, with tests covering a real r95475 payload, the scalar (`uint32`) case, and that the transient `state` field is ignored. `npm run test:js` 2 → 8.

Verified live on a `dreame.vacuum.r95475`: all shortcut channels appear immediately after start with decoded names, and the start button triggers the clean.

Rebased onto v0.4.0.