### PR TITLE
feat(vacuum): add go-to-point — send the robot to a coordinate without cleaning

### DIFF
--- a/go-to-point.test.js
+++ b/go-to-point.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const { expect } = require('chai');
+const { CRUISE_POINT_MODE, buildGoToPointIn, parsePositionPair } = require('./lib/go-to-point');
+
+describe('go-to-point', () => {
+  it('builds the payload that was verified on a device', () => {
+    // Exactly what was written to remote.start-custom-clean on a
+    // dreame.vacuum.r95475 to make it drive to a point without cleaning.
+    expect(buildGoToPointIn(-2194, -397)).to.deep.equal([
+      { piid: 1, value: 23 },
+      { piid: 10, value: '{"tpoint":[[-2194,-397,0,0]]}' },
+    ]);
+    expect(CRUISE_POINT_MODE).to.equal(23);
+  });
+
+  it('refuses coordinates that are not numbers', () => {
+    expect(buildGoToPointIn(NaN, 5)).to.equal(null);
+    expect(buildGoToPointIn(5, NaN)).to.equal(null);
+    expect(buildGoToPointIn(Infinity, 0)).to.equal(null);
+  });
+
+  it('accepts zero as a valid coordinate', () => {
+    expect(buildGoToPointIn(0, 0)).to.not.equal(null);
+  });
+
+  it('reads a coordinate pair from a position state', () => {
+    expect(parsePositionPair('[-2194,-397]')).to.deep.equal({ x: -2194, y: -397 });
+    expect(parsePositionPair([12, 34])).to.deep.equal({ x: 12, y: 34 });
+  });
+
+  it('rejects the 32767 sentinel for an unknown position', () => {
+    // The firmware reports this when it does not know where the dock is.
+    expect(parsePositionPair('[32767,32767]')).to.equal(null);
+  });
+
+  it('rejects unusable position values', () => {
+    expect(parsePositionPair('nonsense')).to.equal(null);
+    expect(parsePositionPair('[1]')).to.equal(null);
+    expect(parsePositionPair('{"x":1,"y":2}')).to.equal(null);
+    expect(parsePositionPair(null)).to.equal(null);
+    expect(parsePositionPair(undefined)).to.equal(null);
+  });
+});

--- a/lib/go-to-point.js
+++ b/lib/go-to-point.js
@@ -1,0 +1,55 @@
+'use strict';
+
+// Helpers for "go to point" (cruise to a map coordinate without cleaning).
+//
+// Kept free of adapter state so the payload shape and the coordinate parsing
+// can be unit tested. The device is driven through the same action as every
+// other start (siid 4 / aiid 1); only the mode and the parameter differ.
+
+// Mode of action 4-1 that makes the robot drive to a point and look around
+// instead of cleaning. Same value the Dreame app uses behind its camera/cruise
+// feature.
+const CRUISE_POINT_MODE = 23;
+
+/**
+ * Build the `in` parameters for action 4-1 that send the robot to one point.
+ *
+ * @param {number} x target x in map coordinates
+ * @param {number} y target y in map coordinates
+ * @returns {{piid: number, value: (number|string)}[]|null} null if x/y are unusable
+ */
+function buildGoToPointIn(x, y) {
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  // The two trailing zeros are fixed fields of a cruise point entry, not
+  // coordinates — the app sends them the same way.
+  const tpoint = JSON.stringify({ tpoint: [[x, y, 0, 0]] });
+  return [
+    { piid: 1, value: CRUISE_POINT_MODE },
+    { piid: 10, value: tpoint },
+  ];
+}
+
+/**
+ * Read a coordinate pair out of the robot/charger position states, which hold
+ * a JSON pair like "[-2194,-397]".
+ *
+ * @param {*} value raw state value
+ * @returns {{x: number, y: number}|null} null if the value is not a usable pair
+ */
+function parsePositionPair(value) {
+  let parsed;
+  try {
+    parsed = typeof value === 'string' ? JSON.parse(value) : value;
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed) || parsed.length < 2) return null;
+  const x = Number(parsed[0]);
+  const y = Number(parsed[1]);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  // 32767 (0x7FFF) is the sentinel the firmware reports for "unknown position".
+  if (Math.abs(x) === 32767 || Math.abs(y) === 32767) return null;
+  return { x, y };
+}
+
+module.exports = { CRUISE_POINT_MODE, buildGoToPointIn, parsePositionPair };

--- a/main.js
+++ b/main.js
@@ -14,6 +14,7 @@ const Json2iob = require('json2iob');
 const crypto = require('node:crypto');
 const mqtt = require('mqtt');
 const zlib = require('node:zlib');
+const { buildGoToPointIn, parsePositionPair } = require('./lib/go-to-point');
 //check if canvas is available because is optional dependency
 let createCanvas;
 let ImageData;
@@ -2856,6 +2857,40 @@ class Dreame extends utils.Adapter {
         await this.setState(_widgetConfigPath, '{}', true);
       }
     }
+
+    // go-to-point: send the robot to a map coordinate without cleaning (cruise mode).
+    // Coordinates use the same system as map.robot / map.charger.
+    await this.extendObject(`${did}.remote.go-to-point`, {
+      type: 'channel',
+      common: { name: 'Go To Point' },
+      native: {},
+    });
+    await this.extendObject(`${did}.remote.go-to-point.x`, {
+      type: 'state',
+      common: { name: 'Target X', type: 'number', role: 'value', read: true, write: true },
+      native: {},
+    });
+    await this.extendObject(`${did}.remote.go-to-point.y`, {
+      type: 'state',
+      common: { name: 'Target Y', type: 'number', role: 'value', read: true, write: true },
+      native: {},
+    });
+    await this.extendObject(`${did}.remote.go-to-point.use-current-position`, {
+      type: 'state',
+      common: {
+        name: 'Copy Current Robot Position Into X/Y',
+        type: 'boolean',
+        role: 'button',
+        read: false,
+        write: true,
+      },
+      native: {},
+    });
+    await this.extendObject(`${did}.remote.go-to-point.start`, {
+      type: 'state',
+      common: { name: 'Go To Point', type: 'boolean', role: 'button', read: false, write: true },
+      native: {},
+    });
 
     this.log.info(
       `Vacuum states created: ${statusStates.length} status, ${remoteStates.length} remote, ${autoSwitchRemotes.length} autoSwitch, ${actionStates.length} actions`,
@@ -5886,6 +5921,47 @@ class Dreame extends utils.Adapter {
             });
             return;
           }
+        }
+        // go-to-point: drive to a map coordinate without cleaning
+        if (id.includes('.remote.go-to-point.')) {
+          const _gtpBase = `${deviceId}.remote.go-to-point`;
+          if (id.endsWith('.use-current-position')) {
+            const _robot = await this.getStateAsync(`${deviceId}.map.robot`);
+            const _pos = _robot ? parsePositionPair(_robot.val) : null;
+            if (!_pos) {
+              this.log.warn(
+                'go-to-point: no usable robot position available. Map data is needed for this — enable "getMap" or wait for the robot to report a map.',
+              );
+            } else {
+              await this.setState(`${_gtpBase}.x`, _pos.x, true);
+              await this.setState(`${_gtpBase}.y`, _pos.y, true);
+              this.log.info(`go-to-point: took current position ${_pos.x}/${_pos.y}`);
+            }
+            await this.setStateAsync(id, false, true);
+            return;
+          }
+          if (id.endsWith('.start')) {
+            const _xs = await this.getStateAsync(`${_gtpBase}.x`);
+            const _ys = await this.getStateAsync(`${_gtpBase}.y`);
+            const _x = Number(_xs && _xs.val);
+            const _y = Number(_ys && _ys.val);
+            const _in = buildGoToPointIn(_x, _y);
+            if (!_in) {
+              this.log.warn('go-to-point: x and y must both be set to a number before starting');
+              await this.setStateAsync(id, false, true);
+              return;
+            }
+            this.log.info(`go-to-point start: ${_x}/${_y}`);
+            await this.sendCommand({
+              did: deviceId,
+              method: 'action',
+              params: { did: deviceId, siid: 4, aiid: 1, in: _in },
+            });
+            await this.setStateAsync(id, false, true);
+            return;
+          }
+          // x / y themselves carry no device command
+          return;
         }
         // custom-room-cleaning: bidirectional sync between checkboxes and customCommand
         if (id.includes('.remote.custom-room-cleaning.')) {


### PR DESCRIPTION
Dreame robots can drive to a point on the map and look around instead of cleaning. In the app this sits behind the camera/cruise feature, which only offers live remote control — there is no way to store a spot and go back to it later. Over MIoT it is just action `4-1` with mode `23` and a `tpoint` parameter, so it maps cleanly onto a datapoint and can be repeated as often as you like (a script, a wall panel button, a REST call).

New states under `remote.go-to-point`:

| state | purpose |
|---|---|
| `x`, `y` | target coordinate, same system as `map.robot` |
| `use-current-position` | copies the robot's current position into `x`/`y` |
| `start` | drives there |

## Verified on a device

On a `dreame.vacuum.r95475`, writing

```
[{"piid":1,"value":23},{"piid":10,"value":"{\"tpoint\":[[-2194,-397,0,0]]}"}]
```

to `remote.start-custom-clean` sends the robot to that point, and it neither vacuums nor mops on the way. The unit test pins exactly this payload, so the wire format is covered by CI rather than by memory.

Mode 23 is `CRUISING_POINT` in Dreame's status enum. Worth noting for review: the neighbouring values in that enum are 18 segment, 19 zone, 25 shortcut — the three this adapter already uses and which are confirmed on real devices. That is what makes 23 trustworthy rather than guessed.

## Design

Built like `remote.custom-room-cleaning`: a channel with control states plus a button, created in `createVacuumRemotes`, sending through the same action path. No new mechanism.

A few deliberate details:

- The two trailing zeros in a `tpoint` entry are fixed fields of the point, not coordinates. Easy to get wrong by hand, which is part of why this belongs in the adapter.
- `use-current-position` reads `map.robot`, so it needs map data to have been decoded at least once. When none is available it logs a warning that names the `getMap` setting rather than writing a stale or bogus coordinate. It also rejects the `32767` sentinel the firmware reports when it does not know a position.
- `start` refuses to send unless both coordinates are real numbers.

Payload building and coordinate parsing live in `lib/go-to-point.js` so both are unit tested — 6 cases, `npm run test:js` goes from 1 to 7.

`npm run lint` clean, `npm run check` unchanged at the 114-error baseline, `npm run test:js` green.

Independent of #97 — different files, no ordering requirement.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>