### PR TITLE
feat(devices): report per-device reachability instead of silent timeouts

### DIFF
--- a/lib/reachability.js
+++ b/lib/reachability.js
@@ -1,0 +1,86 @@
+'use strict';
+
+// Per-device reachability tracking (issue #42, "Device-Offline-Status").
+//
+// The cloud answers a request for a device that is awake with code 0 and one
+// for a device that is asleep or gone with 80001 ("device may be offline,
+// command timed out"). That outcome is the honest reachability signal, so this
+// tracker is driven by request results rather than by a timer: a robot idling
+// on its dock legitimately reports nothing for a long time, so "nothing arrived
+// recently" would produce false offline reports.
+//
+// Kept free of adapter state so the transition logic is unit tested.
+
+/** Consecutive failures before a device is called offline. */
+const DEFAULT_FAILURE_THRESHOLD = 2;
+
+class ReachabilityTracker {
+  /**
+   * @param {number} [failureThreshold] consecutive failures before going offline
+   */
+  constructor(failureThreshold = DEFAULT_FAILURE_THRESHOLD) {
+    this.failureThreshold = Math.max(1, failureThreshold);
+    /** @type {Record<string, {online: (boolean|undefined), failures: number}>} */
+    this.devices = {};
+  }
+
+  _entry(did) {
+    const key = String(did);
+    if (!this.devices[key]) {
+      this.devices[key] = { online: undefined, failures: 0 };
+    }
+    return this.devices[key];
+  }
+
+  /**
+   * Current reachability, `undefined` until the first result arrived.
+   *
+   * @param {string|number} did device id
+   * @returns {boolean|undefined} true if reachable
+   */
+  isOnline(did) {
+    return this._entry(did).online;
+  }
+
+  /**
+   * Record that the device answered.
+   *
+   * @param {string|number} did device id
+   * @returns {boolean} true if this flipped the device to online (caller logs)
+   */
+  recordSuccess(did) {
+    const entry = this._entry(did);
+    entry.failures = 0;
+    // A single answer proves reachability, so recovery is immediate — only the
+    // way into offline is debounced.
+    if (entry.online === true) return false;
+    entry.online = true;
+    return true;
+  }
+
+  /**
+   * Record that the device did not answer (code 80001 / -8).
+   *
+   * @param {string|number} did device id
+   * @returns {boolean} true if this flipped the device to offline (caller logs)
+   */
+  recordFailure(did) {
+    const entry = this._entry(did);
+    entry.failures += 1;
+    if (entry.failures < this.failureThreshold) return false;
+    if (entry.online === false) return false;
+    entry.online = false;
+    return true;
+  }
+
+  /**
+   * Drop a device, e.g. when it disappears from the account.
+   *
+   * @param {string|number} did device id
+   */
+  forget(did) {
+    delete this.devices[String(did)];
+  }
+}
+
+module.exports = { ReachabilityTracker, DEFAULT_FAILURE_THRESHOLD };

--- a/main.js
+++ b/main.js
@@ -14,6 +14,7 @@ const Json2iob = require('json2iob');
 const crypto = require('node:crypto');
 const mqtt = require('mqtt');
 const zlib = require('node:zlib');
+const { ReachabilityTracker } = require('./lib/reachability');
 //check if canvas is available because is optional dependency
 let createCanvas;
 let ImageData;
@@ -411,6 +412,7 @@ class Dreame extends utils.Adapter {
         this.log.error(`Request failed after 3 retries: ${error.message}`);
       },
     });
+    this.reachability = new ReachabilityTracker();
     this.remoteCommands = {};
     this.specStatusDict = {};
     this.specPropsToIdDict = {};
@@ -773,6 +775,26 @@ class Dreame extends utils.Adapter {
               type: 'device',
               common: {
                 name: device.customName || device.deviceInfo.displayName || device.model,
+                // Links the device to its reachability state so Admin and VIS
+                // render the status indicator on the device itself.
+                statusStates: { onlineId: `${this.namespace}.${device.did}.info.online` },
+              },
+              native: {},
+            });
+            await this.extendObject(device.did + '.info', {
+              type: 'channel',
+              common: { name: 'Information' },
+              native: {},
+            });
+            await this.extendObject(device.did + '.info.online', {
+              type: 'state',
+              common: {
+                name: 'Device reachable',
+                type: 'boolean',
+                role: 'indicator.reachable',
+                read: true,
+                write: false,
+                def: false,
               },
               native: {},
             });
@@ -868,6 +890,33 @@ class Dreame extends utils.Adapter {
         error.response && this.log.error('Device list error response: ' + JSON.stringify(error.response.data));
         this.log.error(error.stack);
       });
+  }
+
+  /**
+   * Feed a request outcome into the reachability tracker. Writes
+   * <did>.info.online and logs exactly once per transition, so a device that is
+   * unreachable for hours produces one line instead of one per failed request.
+   *
+   * @param {object} device device record from the device list
+   * @param {boolean} reachable whether the device answered the request
+   */
+  async _updateReachability(device, reachable) {
+    if (!device || device.did === undefined) return;
+    const previous = this.reachability.isOnline(device.did);
+    const changed = reachable
+      ? this.reachability.recordSuccess(device.did)
+      : this.reachability.recordFailure(device.did);
+    if (!changed) return;
+    await this.setStateAsync(`${device.did}.info.online`, reachable, true).catch(() => undefined);
+    const label = `${device.customName || (device.deviceInfo && device.deviceInfo.displayName) || device.model} (${device.did})`;
+    if (!reachable) {
+      this.log.warn(`Device ${label} is not reachable — it will be retried with the next update`);
+    } else if (previous === false) {
+      // Only a real recovery is worth a line. The first result after a start is
+      // just the initial determination and would otherwise announce "reachable
+      // again" on every restart, without the device ever having been away.
+      this.log.info(`Device ${label} is reachable again`);
+    }
   }
 
   async fetchSpecs() {
@@ -3599,6 +3648,10 @@ class Dreame extends utils.Adapter {
             .then(async (res) => {
               if (res.data.code !== 0) {
                 if (res.data.code === -8 || res.data.code === 80001) {
+                  // Device did not answer — this is the offline signal (80001 is
+                  // "device may be offline, command timed out"). Stays on debug;
+                  // the single user-facing line comes from the state transition.
+                  await this._updateReachability(device, false);
                   this.log.debug(
                     `Error getting spec update for ${device.name || device.model} (${device.did}) with ${JSON.stringify(data)}`,
                   );
@@ -3612,6 +3665,8 @@ class Dreame extends utils.Adapter {
                 this.log.debug(JSON.stringify(res.data));
                 return;
               }
+              // Device answered — reachability confirmed.
+              await this._updateReachability(device, true);
               this.log.debug(JSON.stringify(res.data));
               for (const element of res.data.data.result) {
                 const path = await this._lazyCreateState(
@@ -5260,6 +5315,11 @@ class Dreame extends utils.Adapter {
 
         if (res.data.code !== 0) {
           if (res.data.code === 80001) {
+            // Same offline signal as in the property poll. Feeding it in here as
+            // well means a device that goes quiet between two poll cycles is
+            // noticed as soon as the user tries to control it.
+            const timedOutDevice = this.deviceArray.find((d) => String(d.did) === String(data.did));
+            timedOutDevice && this._updateReachability(timedOutDevice, false).catch(() => undefined);
             this.log.debug('Command timeout: ' + JSON.stringify(res.data));
           } else {
             this.log.warn('Command failed: ' + JSON.stringify(res.data));

--- a/reachability.test.js
+++ b/reachability.test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const { expect } = require('chai');
+const { ReachabilityTracker } = require('./lib/reachability');
+
+describe('ReachabilityTracker', () => {
+  it('knows nothing about a device before the first result', () => {
+    expect(new ReachabilityTracker().isOnline('123')).to.equal(undefined);
+  });
+
+  it('reports the first answer as a transition to online', () => {
+    const t = new ReachabilityTracker();
+    expect(t.recordSuccess('123')).to.equal(true);
+    expect(t.isOnline('123')).to.equal(true);
+  });
+
+  it('does not report a transition while the device keeps answering', () => {
+    const t = new ReachabilityTracker();
+    t.recordSuccess('123');
+    expect(t.recordSuccess('123')).to.equal(false);
+    expect(t.recordSuccess('123')).to.equal(false);
+  });
+
+  it('tolerates a single miss before calling a device offline', () => {
+    const t = new ReachabilityTracker();
+    t.recordSuccess('123');
+    expect(t.recordFailure('123')).to.equal(false);
+    expect(t.isOnline('123')).to.equal(true);
+  });
+
+  it('goes offline once the failure threshold is reached', () => {
+    const t = new ReachabilityTracker();
+    t.recordSuccess('123');
+    t.recordFailure('123');
+    expect(t.recordFailure('123')).to.equal(true);
+    expect(t.isOnline('123')).to.equal(false);
+  });
+
+  it('reports the offline transition only once, however long it lasts', () => {
+    const t = new ReachabilityTracker();
+    t.recordSuccess('123');
+    t.recordFailure('123');
+    t.recordFailure('123');
+    for (let i = 0; i < 20; i++) {
+      expect(t.recordFailure('123')).to.equal(false);
+    }
+  });
+
+  it('recovers immediately on the first answer', () => {
+    const t = new ReachabilityTracker();
+    t.recordSuccess('123');
+    t.recordFailure('123');
+    t.recordFailure('123');
+    expect(t.recordSuccess('123')).to.equal(true);
+    expect(t.isOnline('123')).to.equal(true);
+  });
+
+  it('resets the failure count on every answer', () => {
+    const t = new ReachabilityTracker();
+    t.recordSuccess('123');
+    t.recordFailure('123'); // 1 of 2
+    t.recordSuccess('123'); // resets
+    expect(t.recordFailure('123')).to.equal(false); // 1 of 2 again, not offline
+    expect(t.isOnline('123')).to.equal(true);
+  });
+
+  it('keeps devices apart', () => {
+    const t = new ReachabilityTracker();
+    t.recordSuccess('a');
+    t.recordSuccess('b');
+    t.recordFailure('a');
+    t.recordFailure('a');
+    expect(t.isOnline('a')).to.equal(false);
+    expect(t.isOnline('b')).to.equal(true);
+  });
+
+  it('treats numeric and string ids as the same device', () => {
+    const t = new ReachabilityTracker();
+    t.recordSuccess(123);
+    expect(t.isOnline('123')).to.equal(true);
+  });
+
+  it('honours a custom threshold', () => {
+    const t = new ReachabilityTracker(1);
+    t.recordSuccess('123');
+    expect(t.recordFailure('123')).to.equal(true);
+  });
+
+  it('never uses a threshold below one', () => {
+    const t = new ReachabilityTracker(0);
+    expect(t.failureThreshold).to.equal(1);
+  });
+
+  it('forgets a device', () => {
+    const t = new ReachabilityTracker();
+    t.recordSuccess('123');
+    t.forget('123');
+    expect(t.isOnline('123')).to.equal(undefined);
+  });
+});


### PR DESCRIPTION
Adds `<did>.info.online` plus a single log line per transition — the part of #42 that is still open.

## Where that issue actually stands

Points 1 and 3 are already implemented: `axios-retry` with exponential backoff, and `ECONNRESET` on MQTT logged as `info` with a reconnect note. Point 2 was addressed by moving the timeout logging down to `debug`.

That last step went one step too far, though. `80001` is now silent in **both** the property poll and `sendCommand`, and there is no per-device state either — so a robot that has been unreachable for hours produces nothing a user could see. The log went from too loud to too quiet, and the underlying request ("show me that a device is offline, just don't spam me") is still unmet.

## What this adds

- A `<did>.info` channel with `<did>.info.online` (`role: indicator.reachable`), written **only when it actually changes**.
- The device object links to it via `common.statusStates.onlineId`, so Admin and VIS render the status indicator on the device itself rather than the user having to dig for a state.
- One log line per transition — `warn` when a device stops answering, `info` when it answers again. Nothing per failed request, so the noise the issue complained about does not return. The first result after a start only writes the state and stays quiet: it is the initial determination, not a recovery, and would otherwise announce "reachable again" on every restart without the device ever having been away.

## Why outcomes, not a timer

The cloud answers with code `0` when the device is awake and `80001` (*"device may be offline, command timed out"*) when it is not. That outcome is the honest reachability signal, so the tracker is driven by it.

A freshness timeout — "nothing arrived for N minutes, so it must be offline" — would have been wrong here: a robot idling on its dock legitimately reports nothing for a long time and would be flagged offline while being perfectly fine.

Both the poll and `sendCommand` feed the tracker, so a device that goes quiet between two poll cycles is noticed as soon as someone tries to control it.

Going offline is debounced (two consecutive failures) to ride out a single hiccup. Coming back is immediate — one answer proves reachability.

## Tests

The transition logic lives in `lib/reachability.js` and is unit tested: debounce, exactly one transition per state change however long it lasts, immediate recovery, failure-counter reset, device isolation, numeric/string id normalisation. 13 cases, `npm run test:js` goes from 1 to 14.

`npm run lint` clean, `npm run check` unchanged at the 114-error baseline.

Addresses #42.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

