### PR TITLE
Widget: edit the per-room cleaning settings (cleansets)

### DIFF
--- a/www/css/layout.css
+++ b/www/css/layout.css
@@ -523,14 +523,43 @@ input[type="color"]{width:36px; height:28px; padding:2px; border-radius:6px;
 /* Reinigungs-Panel Kachel-Grid (Etappe C, Commit C5): direkte <select>-Elemente statt
    Ricardos Auswahl-Overlay (openPicker/openSlider existieren im modularen Widget noch
    nicht -- siehe reinigung.js-Kommentarkopf). */
-.rraum{font-size:12.5px;opacity:.75;margin-bottom:8px}
+/* min-height/zentriert, damit die Statuszeile GENAU so hoch ist wie der Editor-Kopf
+   (.rfokuskopf) -- beide tauschen (reinigung.js _zeigeBereich), gleiche Hoehe = kein
+   Hoehensprung des Panels beim Oeffnen/Schliessen des Raum-Editors. */
+.rraum{font-size:12.5px;opacity:.75;margin-bottom:8px;min-height:30px;display:flex;align-items:center}
+/* display:flex ist staerker als [hidden] -- ohne diese Zeile bliebe die Statuszeile im
+   Raum-Editor sichtbar (reinigung.js _zeigeBereich setzt hidden), zusaetzlich zum Editor-Kopf,
+   und das Panel waere um eine Zeilenhoehe hoeher. Gleiche Falle wie bei .rgrid/.rfokuskopf. */
+.rraum[hidden]{display:none}
 .rgrid{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:8px}
+/* Ohne diese Zeile bleibt ein .rgrid trotz hidden-Attribut sichtbar: display:grid ist
+   staerker als die Browser-Regel hinter [hidden]. Betrifft das Umschalten global<->Raum-
+   Editor (reinigung.js _zeigeBereich), sonst stehen beide Grids gleichzeitig da. */
+.rgrid[hidden]{display:none}
 .rkarte{display:flex;flex-direction:column;gap:3px;font-size:11.5px;opacity:.85;min-width:0}
+/* Wie bei .rgrid/.rfokuskopf: display:flex ist staerker als [hidden]. Betrifft die
+   modusabhaengig aus-/eingeblendeten Editor-Kacheln (Saugstaerke/Route/Feuchtigkeit) und
+   die bereits vorhandene Feuchtigkeits-Kachel (reinigungWasserKarte). */
+.rkarte[hidden]{display:none}
 .rkarte select{font:inherit;font-size:12.5px;font-weight:700;padding:6px 8px;border-radius:8px;
   border:1px solid var(--line);background:var(--knoepfe);color:var(--txt);min-width:0}
 .rkarte select:disabled{opacity:.4;cursor:not-allowed}
 .rkarte input[type=range]:disabled{opacity:.4;cursor:not-allowed}
 .rk .rkwert{font-weight:800;color:var(--accent,#4a78e0)}
+/* Kopf des Pro-Raum-Editors: "← <Raumname>" ueber den Editor-Kacheln. Ersetzt die
+   .rraum-Zeile, solange ein Raum bearbeitet wird. */
+.rfokuskopf{display:flex;align-items:center;gap:8px;margin-bottom:8px;min-height:30px}
+/* Wie bei .rgrid: display:flex ist staerker als [hidden], sonst bleibt der Editor-Kopf
+   nach dem Zurueck-Knopf stehen. */
+.rfokuskopf[hidden]{display:none}
+/* Icon-Button (Chevron-links aus UI_ICONS, in reinigung.js _renderFokus injiziert) --
+   line-height:0 + inline-flex, damit das SVG sauber mittig sitzt und der Button nicht
+   hoeher wird als noetig. */
+.rzurueck{display:inline-flex;align-items:center;justify-content:center;line-height:0;
+  padding:3px 6px;cursor:pointer;border:1px solid var(--line);border-radius:8px;
+  background:var(--knoepfe);color:var(--txt)}
+.rzurueck:hover{border-color:var(--accent,#4a78e0)}
+.rfokusname{font-size:12.5px;font-weight:800}
 /* Abstand zwischen den Gruppen. Der Wert von 10 px zwischen Auswahl und Steuerung
    bildet den frueheren Zustand nach, als beide noch in einem Block mit gap:10 lagen. */
 .gruppe + .gruppe{margin-top:18px}

--- a/www/icons_ui.js
+++ b/www/icons_ui.js
@@ -14,6 +14,7 @@ window.UI_ICONS = {
   stop: '<rect width="18" height="18" x="3" y="3" rx="2"/>',
   home: '<path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"/><path d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>',
   weiter: '<path d="m9 18 6-6-6-6"/>',
+  zurueck: '<path d="m15 18-6-6 6-6"/>',
   anAn: '<circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/>',
   anAus: '<circle cx="12" cy="12" r="10"/>',
   wasser: '<path d="M12 22a7 7 0 0 0 7-7c0-2-1-3.9-3-5.5s-3.5-4-4-6.5c-.5 2.5-2 4.9-4 6.5C6 11.1 5 13 5 15a7 7 0 0 0 7 7z"/>',

--- a/www/index.html
+++ b/www/index.html
@@ -147,7 +147,13 @@
           <h2>Reinigung</h2>
         </div>
         <div class="rraum" id="reinigungRaum">Raum antippen zum Wählen</div>
-        <div class="rgrid">
+        <!-- Kopf des Pro-Raum-Editors: erscheint statt der globalen Kacheln, wenn ein Raum
+             ueber sein Zahnrad-Badge zum Bearbeiten geoeffnet ist (reinigung.js _fokus). -->
+        <div class="rfokuskopf" id="reinigungFokusKopf" hidden>
+          <button class="rzurueck" id="reinigungZurueck" type="button" aria-label="Zurück"></button>
+          <span class="rfokusname" id="reinigungFokusName"></span>
+        </div>
+        <div class="rgrid" id="reinigungGlobalGrid">
           <label class="rkarte" id="reinigungBetriebKarte">
             <span class="rk">Reinigung</span>
             <select id="reinigungBetrieb"></select>
@@ -167,6 +173,38 @@
           <label class="rkarte" id="reinigungWasserKarte">
             <span class="rk">Feuchtigkeit <span class="rkwert" id="reinigungWasserWert"></span></span>
             <input type="range" id="reinigungWasser" min="1" max="32" step="1">
+          </label>
+        </div>
+        <!-- Pro-Raum-Editor: dieselben Kacheln wie global, aber gebunden an das gespeicherte
+             cleanset EINES Raums (reinigung.js schreibt map.cleanset.<id>.*). Sichtbar nur,
+             wenn ein Raum zum Bearbeiten geoeffnet ist. Feld-Sichtbarkeit je Raum-Modus:
+             Saugstaerke weg bei "nur wischen", Wassermenge weg bei "nur saugen", Route nur
+             bei reinem Wischen -- 1:1 wie HA (segment_available_fn). -->
+        <!-- Kartenreihenfolge EXAKT wie das globale Grid (reinigungGlobalGrid):
+             Zelle 0 = die je Ansicht einzige Sonderkarte (global "Reinigung"=Betriebsart,
+             hier "Wiederholung"), Zellen 1-4 = Modus, Route, Saugstärke, Feuchtigkeit --
+             identisch platziert. Dadurch wandert beim Umschalten global<->Editor KEIN
+             gemeinsames Bedienelement, nur die Sonderkarte auf Zelle 0 wechselt den Inhalt. -->
+        <div class="rgrid" id="reinigungFokusGrid" hidden>
+          <label class="rkarte" id="fokusWdhKarte">
+            <span class="rk">Wiederholung</span>
+            <select id="fokusWdh"></select>
+          </label>
+          <label class="rkarte" id="fokusModusKarte">
+            <span class="rk">Modus</span>
+            <select id="fokusModus"></select>
+          </label>
+          <label class="rkarte" id="fokusRouteKarte">
+            <span class="rk">Route</span>
+            <select id="fokusRoute"></select>
+          </label>
+          <label class="rkarte" id="fokusSaugKarte">
+            <span class="rk">Saugstärke</span>
+            <select id="fokusSaug"></select>
+          </label>
+          <label class="rkarte" id="fokusWasserKarte">
+            <span class="rk">Feuchtigkeit <span class="rkwert" id="fokusWasserWert"></span></span>
+            <input type="range" id="fokusWasser" min="1" max="32" step="1">
           </label>
         </div>
       </section>

--- a/www/index.html
+++ b/www/index.html
@@ -148,6 +148,10 @@
         </div>
         <div class="rraum" id="reinigungRaum">Raum antippen zum Wählen</div>
         <div class="rgrid">
+          <label class="rkarte" id="reinigungBetriebKarte">
+            <span class="rk">Reinigung</span>
+            <select id="reinigungBetrieb"></select>
+          </label>
           <label class="rkarte" id="reinigungModusKarte">
             <span class="rk">Modus</span>
             <select id="reinigungModus"></select>

--- a/www/js/core/trigger.js
+++ b/www/js/core/trigger.js
@@ -57,6 +57,10 @@ const Trigger = (() => {
   const setCleaningRoute = (did, wert) => Daten.setState(pfad(did, 'set-cleaning-route'), wert);
   const setSuctionLevel = (did, wert) => Daten.setState(pfad(did, 'suction-level'), wert);
   const setWetnessLevel = (did, wert) => Daten.setState(pfad(did, 'wetness-level'), wert);
+  // Betriebsart: aus = einheitlich (ein Wert fuer alle Raeume), an = individuell (jeder
+  // Raum nach seinem gespeicherten cleanset). remote.customized-cleaning ist boolean/switch
+  // (SIID 4-26) -- deshalb true/false, nicht 0/1.
+  const setCustomizedCleaning = (did, an) => Daten.setState(pfad(did, 'customized-cleaning'), !!an);
 
   // ===== Tank-Verbrauch (Etappe D, Commit D1d): manueller Reset zusaetzlich zum
   // Auto-Reset-Timer im Adapter (D1c) -- fuer den Fall, dass der Nutzer sofort
@@ -112,7 +116,7 @@ const Trigger = (() => {
     startCleaning, startCustomRoomCleaning, stopCleaning, chargeHome,
     resetMainBrush, resetSideBrush, resetFilter, resetSensor,
     startWashing, startAutoEmpty, resumeWashing, pauseWashing, startDrying, stopDrying,
-    setCleaningMode, setCleaningRoute, setSuctionLevel, setWetnessLevel,
+    setCleaningMode, setCleaningRoute, setSuctionLevel, setWetnessLevel, setCustomizedCleaning,
     resetTankCounter,
   };
 })();

--- a/www/js/core/trigger.js
+++ b/www/js/core/trigger.js
@@ -62,6 +62,14 @@ const Trigger = (() => {
   // (SIID 4-26) -- deshalb true/false, nicht 0/1.
   const setCustomizedCleaning = (did, an) => Daten.setState(pfad(did, 'customized-cleaning'), !!an);
 
+  // ===== Pro-Raum-Einstellungen ins gespeicherte cleanset schreiben (Individuell-Betrieb).
+  // Feld = Level | WaterVolume | CleaningMode | Route | Repeat. Der Adapter (main.js
+  // UpdateRoomSettings -> customeClean) liest die uebrigen Felder des Raums dazu und
+  // uebertraegt alle sechs dauerhaft ans Geraet -- die Aenderung ueberlebt also den
+  // naechsten App-Start, anders als die globalen Kacheln. =====
+  const cleansetPfad = (did, raumId, feld) => `dreame.0.${did}.map.cleanset.${raumId}.${feld}`;
+  const setCleansetFeld = (did, raumId, feld, wert) => Daten.setState(cleansetPfad(did, raumId, feld), wert);
+
   // ===== Tank-Verbrauch (Etappe D, Commit D1d): manueller Reset zusaetzlich zum
   // Auto-Reset-Timer im Adapter (D1c) -- fuer den Fall, dass der Nutzer sofort
   // zuruecksetzen will oder die 10s-Erkennung mal danebenliegt. =====
@@ -117,6 +125,7 @@ const Trigger = (() => {
     resetMainBrush, resetSideBrush, resetFilter, resetSensor,
     startWashing, startAutoEmpty, resumeWashing, pauseWashing, startDrying, stopDrying,
     setCleaningMode, setCleaningRoute, setSuctionLevel, setWetnessLevel, setCustomizedCleaning,
+    setCleansetFeld,
     resetTankCounter,
   };
 })();

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -26,7 +26,7 @@
  * Siehe WIDGET_SESSION_STATUS.md fuer die vollstaendige Herleitung dieser Entscheidung.
  */
 
-/* global Daten, Geraete, Config, PanelRegistry, KopfPanel, WartungPanel, StatistikPanel, StationPanel, ReinigungPanel, FehlerPanel, WasserMoppPanel, uiIcon */
+/* global Daten, Geraete, Config, PanelRegistry, KopfPanel, WartungPanel, StatistikPanel, StationPanel, ReinigungPanel, FehlerPanel, WasserMoppPanel, uiIcon, bearbeiteRaum */
 
 // ===== Zustand (verbatim aus www/legacy.html "Zustand"-Bereich uebernommen, minus SOCK —
 // die alte direkte Socket.io-Sendefunktion cmd() wird nicht mehr gebraucht, Trigger/Daten
@@ -625,7 +625,7 @@ function zeigeVerbindung(wert) {
 // clamp, applyT, hitRoom, selectRoom aus overlays.js/render.js), nur ohne die UI-Chrome. =====
 function initZoomPan() {
   stage.addEventListener('wheel', e => { e.preventDefault(); zoomAt(e.clientX, e.clientY, e.deltaY < 0 ? 1.15 : 1 / 1.15); }, { passive: false });
-  let drag = false, lx = 0, ly = 0, sx0 = 0, sy0 = 0;
+  let drag = false, lx = 0, ly = 0, sx0 = 0, sy0 = 0, downT = null;
   // #devName ausgenommen seit Etappe E1 (Roboter-Umschalter): sonst faengt
   // setPointerCapture() jeden Klick darauf als Kartendrag/Raumklick ab, bevor
   // devNameEl.onclick ueberhaupt feuert -- gleiches Prinzip wie bei .zoom oben.
@@ -633,6 +633,9 @@ function initZoomPan() {
     || t.closest('#zahnradBtn') || t.closest('#zahnradOvl')));
   stage.addEventListener('pointerdown', e => {
     if (aufBedienung(e.target)) return;
+    // Ziel HIER merken: setPointerCapture() leitet spaetere Events (pointerup) auf `stage`
+    // um, dann waere das getippte Badge nicht mehr am e.target erkennbar.
+    downT = e.target;
     drag = true; lx = e.clientX; ly = e.clientY; sx0 = e.clientX; sy0 = e.clientY;
     wrap.classList.add('drag'); stage.setPointerCapture(e.pointerId);
   });
@@ -642,7 +645,13 @@ function initZoomPan() {
     drag = false; wrap.classList.remove('drag');
     const moved = Math.hypot(e.clientX - sx0, e.clientY - sy0);
     const schwelle = (e.pointerType === 'touch' || e.pointerType === 'pen') ? 12 : 5;
-    if (moved < schwelle) { const seg = hitRoom(e.clientX, e.clientY); if (seg != null) selectRoom(seg); }
+    if (moved < schwelle) {
+      // Tap aufs Zahnrad-Badge (nur im Individuell-Betrieb vorhanden, Klasse ohne "starr")
+      // oeffnet den Pro-Raum-Editor; ein Tap NEBEN das Badge auf die Raumflaeche waehlt aus.
+      const bdg = downT && downT.closest && downT.closest('.rbadge:not(.starr)');
+      if (bdg) bearbeiteRaum(+bdg.dataset.raum);
+      else { const seg = hitRoom(e.clientX, e.clientY); if (seg != null) selectRoom(seg); }
+    }
   });
   const ctr = () => { const r = stage.getBoundingClientRect(); return [r.left + r.width / 2, r.top + r.height / 2]; };
   document.getElementById('z-in').onclick = () => zoomAt(...ctr(), 1.3);

--- a/www/js/panels/reinigung.js
+++ b/www/js/panels/reinigung.js
@@ -237,12 +237,30 @@ class ReinigungPanel extends Panel {
 
   render() {
     if (!this.container) return;
+    this._renderBetrieb();
     this._renderRaum();
     this._renderModus();
     this._renderRoute();
     this._renderSaug();
     this._renderWasser();
     updateRoomBadges();
+  }
+
+  /** Betriebsart-Umschalter (remote.customized-cleaning). Aus = einheitlich, an = individuell.
+   * Bestimmt, ob die globalen Kacheln (Modus/Route/Saug/Wasser) gelten oder das je Raum
+   * gespeicherte cleanset -- deshalb werden die Kacheln bei "individuell" ausgegraut
+   * (customizedCleaning-Pruefung in _renderModus/_renderRoute/_renderSaug/_renderWasser).
+   * Waehrend einer Fahrt gesperrt: die Betriebsart legt fest, WAS fuer ein Auftrag laeuft. */
+  _renderBetrieb() {
+    const el = document.getElementById('reinigungBetrieb');
+    if (!el) return;
+    if (!el.dataset.gefuellt) {
+      el.innerHTML = '<option value="0">Einheitlich</option><option value="1">Individuell pro Raum</option>';
+      el.dataset.gefuellt = '1';
+      el.onchange = () => Trigger.setCustomizedCleaning(this.did, el.value === '1');
+    }
+    if (this.custom != null) el.value = this.custom ? '1' : '0';
+    el.disabled = geraetGestartet();
   }
 
   // Etappe C6-4 (WIDGET_UMBAU_PLAN.md Abschnitt 6.4): "aktiv" vs. "gewählt" ist bewusst

--- a/www/js/panels/reinigung.js
+++ b/www/js/panels/reinigung.js
@@ -59,7 +59,7 @@
  * Betriebsart.
  */
 
-/* global Panel, Trigger, Daten, geraetGestartet, updateRoomBadges, drawFills, updateLabels */
+/* global Panel, uiIcon, Trigger, Daten, geraetGestartet, updateRoomBadges, drawFills, updateLabels, roomName, META */
 
 // ===== Reinigungsmodus: EINE Auswahl aus vier, wie das Geraet es kennt (remote.cleaning-mode,
 // vom Adapter bereits auf 0-3 dekodiert — siehe lib/specs/cleaning.js CLEANING_MODE_DECODE). =====
@@ -87,6 +87,34 @@ const routenFuer = m => ((m === 0 || m === 2) ? CLEAN_ROUTES.filter(r => r.id !=
 
 const SUCT_NAMES = ['Leise', 'Standard', 'Stark', 'Turbo'];
 
+// ===== Pro-Raum-Editor (Individuell-Betrieb): das je Raum gespeicherte cleanset bearbeiten.
+// "Wischen nach Saugen" (Modus 3) gibt es hier NICHT -- das ist ein Ablauf fuer die ganze
+// Wohnung, kein Raum-Modus (1:1 HA device.py 745-747, entfernt MOPPING_AFTER_SWEEPING aus
+// der Segment-Liste).
+//
+// WICHTIG -- die Modus-IDs stehen hier ROH, ohne den 0<->2-Tausch fuer Geraete mit
+// Mopp-Anhebung. Der Tausch gilt nur fuer den GLOBALEN cleaning-mode: den dekodiert/kodiert
+// der Adapter ueber die Spec (lib/specs/cleaning.js CLEANING_MODE_DECODE, angewandt in
+// main.js ueber deviceHasMopPadLifting). Der cleanset-CleaningMode laeuft dagegen ungetauscht
+// durch (main.js onStateChange -> UpdateRoomSettings ChangeType 4 -> customeClean).
+// Live geprueft an einem X40 Ultra (Waschstation 4-25 + Absaugstation 15-5, also Tausch beim
+// globalen Modus aktiv): was hier im Editor eingestellt wird, zeigt die Dreame-App fuer
+// denselben Raum unveraendert an. Hier also NICHT "der Einheitlichkeit halber" tauschen --
+// das wuerde Saugen und Saugen+Wischen je Raum vertauschen. =====
+const ROOM_MODES = [
+  { id: 0, name: 'Saugen' },
+  { id: 1, name: 'Wischen' },
+  { id: 2, name: 'Saugen und Wischen' },
+];
+// Route je Raum: dieselbe Liste wie global, aber ohne "Schnell" -- HA nimmt QUICK bei der
+// Segment-Route heraus (device.py 760-763, segment_slow_clean_route).
+const RAUM_ROUTEN = CLEAN_ROUTES.filter(r => r.id !== 4);
+const ROOM_REPEATS = [
+  { id: 1, name: '1×' },
+  { id: 2, name: '2×' },
+  { id: 3, name: '3×' },
+];
+
 // ===== Globale Bruecken-Werte fuer den Karten-Layer (render.js' baueBadge()/updateRoomBadges(),
 // seit B2/B5 unveraendert) — ERSETZEN main.js' B5-Platzhalter, siehe Kommentarkopf oben. =====
 // selectedRooms zog mit Etappe C5.5 (Commit 3) von main.js hierher um: seit C5.5-2 ist es
@@ -99,13 +127,19 @@ let customizedCleaning = false;
 let globalSaug = 1;
 let globalWasser = 3;
 let cleanMode = 0;
-// Punkt 2 im Kommentarkopf: kein Pro-Raum-Editor in diesem Commit, daher immer der globale
-// Wert — unabhaengig davon, ob customizedCleaning an oder aus ist.
-const raumSaugt = () => modeSaugt(cleanMode);
-const raumWischt = () => modeWischt(cleanMode);
-const raumWdh = () => 1;
-const raumSaug = () => globalSaug;
-const raumWasser = () => globalWasser;
+// Pro-Raum-cleanset fuer die Karten-Badges: raumId -> RoomSettings-Array
+// [Level, WaterVolume, Repeat, RoomOrder, CleaningMode, Route] (Reihenfolge live verifiziert
+// an map.cleanset.<id>.RoomSettings, z.B. [1,15,1,5,2,1]). Befuellt durch das cleanset-
+// Muster-Abo (_merkeCleanset/_ladeCleansets unten).
+const roomCleanset = {};
+// Im Individuell-Betrieb zeigen die Badges die je Raum gespeicherten Werte, sonst (einheitlich
+// oder cleanset noch nicht geladen) den globalen. render.js' baueBadge() ruft diese mit der
+// Raum-ID auf und entscheidet selbst zwischen einheitlich (globalSaug/-Wasser) und individuell.
+const raumSaugt = id => { const cs = roomCleanset[id]; return (customizedCleaning && cs) ? modeSaugt(Number(cs[4])) : modeSaugt(cleanMode); };
+const raumWischt = id => { const cs = roomCleanset[id]; return (customizedCleaning && cs) ? modeWischt(Number(cs[4])) : modeWischt(cleanMode); };
+const raumWdh = id => { const cs = roomCleanset[id]; return (customizedCleaning && cs) ? (Number(cs[2]) || 1) : 1; };
+const raumSaug = id => { const cs = roomCleanset[id]; return (customizedCleaning && cs) ? Number(cs[0]) : globalSaug; };
+const raumWasser = id => { const cs = roomCleanset[id]; return (customizedCleaning && cs) ? Number(cs[1]) : globalWasser; };
 
 class ReinigungPanel extends Panel {
   constructor(id, container) {
@@ -122,6 +156,10 @@ class ReinigungPanel extends Panel {
     this._mapId = null;
     this._raumMuster = null;
     this._raumVonState = {}; // State-ID -> numerische Raum-ID (native.roomId)
+    // Pro-Raum-Editor: _fokus = gerade bearbeiteter Raum (null = globale Ansicht),
+    // _fokusCS = dessen cleanset als { Level, WaterVolume, CleaningMode, Repeat, Route }.
+    this._fokus = null;
+    this._fokusCS = null;
   }
 
   benoetigteStates(did) {
@@ -134,9 +172,20 @@ class ReinigungPanel extends Panel {
     return [this._idModus, this._idRoute, this._idSaug, this._idWasser, this._idCustom, this._idActiveMap];
   }
 
+  /** Pro-Raum-cleanset (RoomSettings aller Raeume) fuer die Karten-Badges abonnieren. Das
+   * Raum-Checkbox-Muster kommt dynamisch dazu (_aktualisiereRaumMuster, haengt an der aktiven
+   * Karte); das cleanset haengt an der aktuellen Karte generell, deshalb hier statisch. */
+  benoetigteMuster(did) {
+    this._idCleansetMuster = `dreame.0.${did}.map.cleanset.*.RoomSettings`;
+    return [this._idCleansetMuster];
+  }
+
   init(did) {
     reinigungInstanz = this; // Bruecke fuer updateCleanPanel(), siehe Kommentarkopf
-    return super.init(did);
+    // Nach dem Basis-Init die aktuellen cleanset-Werte einmal nachladen -- das Muster-Abo
+    // liefert nur kuenftige Aenderungen, die Badges brauchen aber sofort die gespeicherten
+    // Raum-Werte (gleicher Grund wie das getState() fuer feste States in Panel.init()).
+    return super.init(did).then(() => this._ladeCleansets(did));
   }
 
   neueDaten(stateId, wert) {
@@ -198,11 +247,32 @@ class ReinigungPanel extends Panel {
     this.render();
   }
 
+  /** Ein RoomSettings-State in roomCleanset uebernehmen. Wert ist ein Array (oder dessen
+   * JSON-Text) [Level, WaterVolume, Repeat, RoomOrder, CleaningMode, Route]. Liefert true,
+   * wenn es ein cleanset-State war (dann NICHT als Raum-Checkbox weiterbehandeln). */
+  _merkeCleanset(stateId, wert) {
+    const m = stateId.match(/\.map\.cleanset\.(\d+)\.RoomSettings$/);
+    if (!m) return false;
+    let arr = wert;
+    if (typeof arr === 'string') { try { arr = JSON.parse(arr); } catch (e) { return true; } }
+    if (Array.isArray(arr)) roomCleanset[m[1]] = arr;
+    return true;
+  }
+
+  /** Aktuelle cleanset-Werte aller Raeume einmal laden (Startwerte, s. init()). */
+  async _ladeCleansets(did) {
+    const werte = await Daten.getStates(`dreame.0.${did}.map.cleanset.*.RoomSettings`);
+    for (const [stateId, st] of Object.entries(werte || {})) this._merkeCleanset(stateId, st && st.val);
+    updateRoomBadges();
+  }
+
   /** Eingehende Checkbox-Aenderung (Klick am Adapter, Objekt-Editor, Skript, ...) in die
    * lokale Auswahl uebernehmen und die Karte neu zeichnen. Bewusst NICHT auf
    * document.activeElement/eigene Klicks pruefen wie bei _renderWasser() -- hier gibt es
    * (noch) kein Eingabeelement, das waehrend der Eingabe verfaelscht werden koennte. */
   neueDatenMuster(stateId, wert) {
+    // Erst pruefen, ob es ein cleanset-State ist (fuer die Badges), sonst Raum-Checkbox.
+    if (this._merkeCleanset(stateId, wert)) { updateRoomBadges(); return; }
     const raumId = this._raumVonState[stateId];
     if (raumId === undefined) return;
     if (wert) selectedRooms.add(raumId); else selectedRooms.delete(raumId);
@@ -237,13 +307,153 @@ class ReinigungPanel extends Panel {
 
   render() {
     if (!this.container) return;
-    this._renderBetrieb();
-    this._renderRaum();
-    this._renderModus();
-    this._renderRoute();
-    this._renderSaug();
-    this._renderWasser();
+    // Pro-Raum-Editor nur im Individuell-Betrieb und nicht waehrend der Fahrt. Aendert sich
+    // eins davon, waehrend der Editor offen ist, zurueck zur globalen Ansicht.
+    if (this._fokus != null && (!customizedCleaning || geraetGestartet())) this._fokus = null;
+    const imEditor = this._fokus != null;
+    this._zeigeBereich(imEditor);
+    if (imEditor) {
+      this._renderFokus();
+    } else {
+      this._renderBetrieb();
+      this._renderRaum();
+      this._renderModus();
+      this._renderRoute();
+      this._renderSaug();
+      this._renderWasser();
+    }
     updateRoomBadges();
+  }
+
+  /** Umschalten der Panel-Ansicht: globale Kacheln vs. Pro-Raum-Editor. Dieselben DOM-Bloecke
+   * bleiben stehen, nur ihre Sichtbarkeit wechselt -- kein Neuaufbau, kein Popup. */
+  _zeigeBereich(imEditor) {
+    const setzeSichtbar = (id, sichtbar) => { const el = document.getElementById(id); if (el) el.hidden = !sichtbar; };
+    setzeSichtbar('reinigungGlobalGrid', !imEditor);
+    setzeSichtbar('reinigungRaum', !imEditor);
+    setzeSichtbar('reinigungFokusKopf', imEditor);
+    setzeSichtbar('reinigungFokusGrid', imEditor);
+  }
+
+  /** Einen Raum zum Bearbeiten oeffnen (Klick auf sein Zahnrad-Badge, main.js). Laedt das
+   * gespeicherte cleanset des Raums und zeigt den Editor. Nur im Individuell-Betrieb und nicht
+   * waehrend der Fahrt -- ausserhalb davon traegt das Badge ohnehin kein Zahnrad (render.js
+   * baueBadge nurAnzeige). */
+  async bearbeiteRaum(seg) {
+    if (!customizedCleaning || geraetGestartet() || this.did == null) return;
+    const basis = `dreame.0.${this.did}.map.cleanset.${seg}.`;
+    const werte = await Daten.getStates(basis + '*');
+    if (this.did == null) return; // waehrenddessen abgebaut
+    const val = feld => { const st = werte[basis + feld]; return st == null ? null : st.val; };
+    this._fokusCS = {
+      Level: Number(val('Level') ?? 1),
+      WaterVolume: Number(val('WaterVolume') ?? 3),
+      CleaningMode: Number(val('CleaningMode') ?? 0),
+      Repeat: Number(val('Repeat') ?? 1),
+      Route: Number(val('Route') || 1), // 0 = nicht gesetzt -> Standard, wie HA (select.py 683)
+    };
+    this._fokus = seg;
+    this.render();
+  }
+
+  /** Zurueck zur globalen Ansicht (← -Knopf). */
+  schliesseRaum() {
+    this._fokus = null;
+    this._fokusCS = null;
+    this.render();
+  }
+
+  /** Position eines cleanset-Feldes im RoomSettings-Array (siehe _merkeCleanset):
+   * [Level, WaterVolume, Repeat, RoomOrder, CleaningMode, Route]. */
+  static CS_INDEX = { Level: 0, WaterVolume: 1, Repeat: 2, RoomOrder: 3, CleaningMode: 4, Route: 5 };
+
+  /** Ein Feld des fokussierten Raums schreiben. Der Adapter (UpdateRoomSettings) liest die
+   * uebrigen Felder dazu und uebertraegt alle sechs ans Geraet. Lokalen Wert sofort nachziehen,
+   * damit die Modus-abhaengige Sichtbarkeit ohne Wartezeit auf den Round-Trip stimmt.
+   * Dasselbe fuer roomCleanset: daraus speisen sich die Badges auf der Karte, und die haengen
+   * am RoomSettings-Abo -- schreibt man nur das Einzelfeld, bliebe das Badge bis zum (evtl.
+   * ausbleibenden) RoomSettings-Update auf dem alten Wert stehen. */
+  _schreibeCS(feld, wert) {
+    if (this._fokus == null || !this._fokusCS) return;
+    Trigger.setCleansetFeld(this.did, this._fokus, feld, wert);
+    this._fokusCS[feld] = wert;
+    const arr = roomCleanset[this._fokus];
+    const idx = ReinigungPanel.CS_INDEX[feld];
+    if (Array.isArray(arr) && idx !== undefined) arr[idx] = wert;
+    this.render(); // ruft am Ende updateRoomBadges()
+  }
+
+  /** Editor-Ansicht fuellen: Name im Kopf, dann die Kacheln aus dem cleanset des Raums.
+   * Welche Felder fuer den Raum-Modus gelten, haengt am Modus -- 1:1 wie global bzw. HA
+   * segment_available_fn: Saugstaerke nur wenn der Raum saugt, Wassermenge nur wenn er wischt,
+   * Route nur bei reinem Wischen. Unpassende Felder werden NICHT versteckt, sondern ausgegraut
+   * mit "nicht verfügbar" (siehe _fokusSelect/_fokusWasser) -- damit die Kachelzahl konstant
+   * bleibt und beim Oeffnen/Moduswechsel nichts springt. */
+  _renderFokus() {
+    const cs = this._fokusCS; if (!cs) return;
+    const zurueck = document.getElementById('reinigungZurueck');
+    if (zurueck && !zurueck.dataset.gefuellt) { zurueck.dataset.gefuellt = '1'; zurueck.innerHTML = uiIcon('zurueck', 20); zurueck.onclick = () => this.schliesseRaum(); }
+    const nameEl = document.getElementById('reinigungFokusName');
+    if (nameEl) nameEl.textContent = roomName(this._fokus, META && META.seg_inf);
+
+    const m = cs.CleaningMode;
+    this._fokusSelect('fokusModus', ROOM_MODES, m, true, v => this._schreibeCS('CleaningMode', v));
+    this._fokusSelect('fokusSaug', SUCT_NAMES.map((n, i) => ({ id: i, name: n })), cs.Level, modeSaugt(m), v => this._schreibeCS('Level', v));
+    this._fokusSelect('fokusRoute', RAUM_ROUTEN, cs.Route, m === 1, v => this._schreibeCS('Route', v));
+    this._fokusSelect('fokusWdh', ROOM_REPEATS, cs.Repeat, true, v => this._schreibeCS('Repeat', v));
+    this._fokusWasser(modeWischt(m));
+  }
+
+  /** Ein <select> im Editor fuellen/spiegeln. Gilt das Feld fuer den Raum-Modus nicht
+   * (anwendbar=false), bleibt die Kachel stehen, wird aber gesperrt und zeigt
+   * "nicht verfügbar" -- gleiche ruhige Darstellung wie die einheitliche Ansicht, die
+   * unpassende Kacheln ebenfalls nur ausgraut statt zu verstecken. So bleibt die Zahl der
+   * Kacheln konstant und das Raster springt beim Oeffnen des Editors bzw. beim Moduswechsel
+   * nicht (Davids Kiosk-Vorgabe: keine wandernde Anzeige). */
+  _fokusSelect(selId, optionen, wert, anwendbar, onWahl) {
+    const el = document.getElementById(selId);
+    if (!el) return;
+    if (!anwendbar) {
+      el.innerHTML = '<option>nicht verfügbar</option>';
+      el.dataset.schluessel = '';   // beim Wiederfreischalten Optionen neu fuellen
+      el.disabled = true;
+      el.onchange = null;
+      return;
+    }
+    el.disabled = false;
+    const schluessel = optionen.map(o => o.id).join(',');
+    if (el.dataset.schluessel !== schluessel) {
+      el.innerHTML = optionen.map(o => `<option value="${o.id}">${o.name}</option>`).join('');
+      el.dataset.schluessel = schluessel;
+    }
+    if (wert != null && optionen.some(o => o.id === Number(wert))) el.value = String(wert);
+    el.onchange = () => onWahl(Number(el.value));
+  }
+
+  /** Feuchtigkeits-Regler im Editor (1-32), analog _renderWasser, ans cleanset gebunden.
+   * Wischt der Raum nicht (anwendbar=false), bleibt die Kachel stehen, der Regler ist
+   * gesperrt und der Wert zeigt "nicht verfügbar" -- wie _fokusSelect, damit die Anzeige
+   * stabil bleibt statt eine Kachel wegfallen zu lassen. */
+  _fokusWasser(anwendbar) {
+    const el = document.getElementById('fokusWasser');
+    const wertEl = document.getElementById('fokusWasserWert');
+    if (!el) return;
+    if (!anwendbar) {
+      el.disabled = true;
+      el.style.setProperty('--fill', '0%');
+      if (wertEl) wertEl.textContent = 'nicht verfügbar';
+      return;
+    }
+    el.disabled = false;
+    const fuellen = () => {
+      const pct = (Number(el.value) - Number(el.min)) / (Number(el.max) - Number(el.min)) * 100;
+      el.style.setProperty('--fill', pct + '%');
+      if (wertEl) wertEl.textContent = el.value;
+    };
+    if (document.activeElement !== el) el.value = String(this._fokusCS.WaterVolume);
+    fuellen();
+    el.oninput = fuellen;
+    el.onchange = () => this._schreibeCS('WaterVolume', Number(el.value));
   }
 
   /** Betriebsart-Umschalter (remote.customized-cleaning). Aus = einheitlich, an = individuell.
@@ -274,16 +484,19 @@ class ReinigungPanel extends Panel {
     el.textContent = n === 0 ? 'Alle Räume aktiv' : (n === 1 ? '1 Raum gewählt' : n + ' Räume gewählt');
   }
 
-  /** Bei Raum-Auswahl waehlt das X40 den Modus pro Raum selbst und ignoriert den globalen
-   * remote.cleaning-mode (live verifiziert, siehe WIDGET_SESSION_STATUS.md Etappe C5.5-Test
-   * "X40-Eigenheit, kein Bug"). Die Kachel bliebe sonst bedienbar, obwohl die Einstellung beim
-   * Start wirkungslos ist -- deshalb hier ausgegraut + Tooltip statt stillschweigend falscher
-   * Anzeige (Plan Abschnitt 6, Commit C6-3). Tooltip sitzt auf der umschliessenden .rkarte,
-   * nicht auf dem <select> selbst: disabled-Formelemente feuern in den meisten Browsern keine
-   * hover-Events, ein title auf dem <select> wuerde also nie sichtbar werden. */
+  /** Der globale Modus wird NUR im Individuell-Betrieb gesperrt -- dort gilt je Raum der im
+   * Cleanset gespeicherte Modus (im Editor bearbeitbar), der globale hat keine Wirkung.
+   *
+   * Frueher war die Kachel zusaetzlich gesperrt, sobald ueberhaupt ein Raum ausgewaehlt war
+   * ("bei Raum-Reinigung waehlt das Geraet den Modus selbst"). Das stimmt fuer den
+   * Einheitlich-Betrieb NICHT: der globale Modus wirkt dort auch bei Raum-Auswahl -- live
+   * gegengeprueft (zwei Raeume ausgewaehlt, global "Wischen" -> beide gewischt). Der Adapter
+   * schickt den globalen Modus vor jedem Raum-Start ohnehin nochmal mit
+   * (_preSendCleaningProperties), was das bestaetigt. Route/Saugstaerke/Wassermenge waren bei
+   * Raum-Auswahl nie gesperrt -- die Sonderbehandlung des Modus war also auch in sich
+   * inkonsistent. Deshalb hier entfernt. */
   _renderModus() {
     const el = document.getElementById('reinigungModus');
-    const karte = document.getElementById('reinigungModusKarte');
     if (!el) return;
     if (!el.dataset.gefuellt) {
       el.innerHTML = CLEAN_MODES.map(m => `<option value="${m.id}">${m.name}</option>`).join('');
@@ -291,9 +504,7 @@ class ReinigungPanel extends Panel {
       el.onchange = () => Trigger.setCleaningMode(this.did, Number(el.value));
     }
     if (this.modus != null) el.value = String(this.modus);
-    const raumAktiv = selectedRooms.size > 0;
-    el.disabled = customizedCleaning || geraetGestartet() || raumAktiv;
-    if (karte) karte.title = raumAktiv ? 'Bei Raum-Reinigung wählt das Gerät den Modus selbst' : '';
+    el.disabled = customizedCleaning || geraetGestartet();
   }
 
   _renderRoute() {
@@ -365,3 +576,8 @@ function updateCleanPanel() { if (reinigungInstanz) reinigungInstanz.render(); }
 // render.js' selectRoom() ruft das statt eines lokalen Set-Toggles auf, gleiches
 // Bruecken-Muster wie updateCleanPanel() direkt darueber.
 function raumUmschalten(seg) { if (reinigungInstanz) reinigungInstanz.raumUmschalten(seg); }
+
+// Bruecke fuer den Pro-Raum-Editor: render.js/main.js ruft das beim Tap auf ein
+// Zahnrad-Badge auf (Feature A -- Tap auf die Raumflaeche waehlt weiter aus, Tap aufs Badge
+// oeffnet den Editor). Gleiches Bruecken-Muster wie raumUmschalten() direkt darueber.
+function bearbeiteRaum(seg) { if (reinigungInstanz) reinigungInstanz.bearbeiteRaum(seg); }


### PR DESCRIPTION
## Problem

The adapter has been able to read and write the per-room cleaning settings for a while
(`map.cleanset.<room>.*`, written through `UpdateRoomSettings` → `customeClean`, which
persists them on the device). The widget had no UI for them, so the stored per-room values
were only reachable through the object tree or the Dreame app — in the widget you could
only set one value for the whole flat.

## What this adds

* **Operating mode selector** in the cleaning panel: *Einheitlich* (uniform) / *Individuell
  pro Raum* (per room), writing `remote.customized-cleaning`.
* **Per-room editor**: in per-room mode each room badge carries a gear icon; tapping it
  opens that room's settings **inline in the panel** — no popup, to stay consistent with the
  kiosk-friendly direction of 0.4.0. Back arrow returns to the global view.
  Editable per room: mode, suction level, route, wetness, repeats.
* **Badges** show the per-room values in per-room mode instead of repeating the global one,
  and update immediately when a value is changed.
* Tapping the room area still only selects the room — only the gear opens the editor, so
  selecting and editing never collide.

Values are written per field to `map.cleanset.<room>.<field>`; the adapter reads the
remaining fields and transfers all six, so the change persists on the device and shows up
in the Dreame app.

## Parity with the HA integration

* "Mopping after sweeping" is not offered as a room mode — it is a whole-flat sequence
  (`device.py` 745-747 removes `MOPPING_AFTER_SWEEPING` from the segment list).
* Room route list without "Quick" (`device.py` 760-763, `segment_slow_clean_route`).
* Route is only applicable to a room when that room is mopping-only (`select.py` 676-679).

## Fixes an existing bug

The global cleaning-mode tile was disabled as soon as rooms were selected, on the
assumption that the global mode does not apply to a room-specific job. That is not the
case: with two rooms selected and mode "mopping", **both rooms were mopped** (tested on an
X40 Ultra). Since a per-room mode did not exist before this PR, the tile was effectively
unreachable whenever a room was selected, even though it was in charge.

The tile is now disabled only in per-room mode (where the mode belongs to the room editor)
and while a job is running.

## Verified on hardware

Tested on a Dreame X40 Ultra:

* Values set in the editor appear unchanged for the same room in the Dreame app.
* This also confirms that the **cleanset** `CleaningMode` is *not* subject to the 0↔2
  mop-pad-lifting swap that the global `cleaning-mode` goes through
  (`lib/specs/cleaning.js` `CLEANING_MODE_DECODE`, applied via `deviceHasMopPadLifting`).
  The device qualifies for the swap, and the values still match 1:1. This is recorded as a
  comment on `ROOM_MODES` so it does not get "unified" later.

## UI notes

The editor grid uses the same cell layout as the global grid, so no control moves when
switching between them; the status line and the editor header have the same height for the
same reason. Fields that do not apply to the selected room mode are greyed out and labelled
"nicht verfügbar" rather than hidden — hiding them changed the number of tiles and made the
layout jump.

## Files

`www/index.html`, `www/css/layout.css`, `www/icons_ui.js` (chevron-left icon for the back
button), `www/js/core/trigger.js` (`setCustomizedCleaning`, `setCleansetFeld`),
`www/js/main.js` (pointer routing: gear on badge vs. room area), `www/js/panels/reinigung.js`.

## How to test

1. Set *Reinigung* to **Individuell pro Raum** — the global mode/route/suction/wetness tiles
   grey out, the room badges get a gear.
2. Tap a gear, change mode / suction / wetness / repeats — the badge follows immediately,
   and `map.cleanset.<room>.RoomSettings` updates in the object tree.
3. Check the same room in the Dreame app: it shows the values set here.
4. Switch back to **Einheitlich** — the global tiles become editable again, including while
   rooms are selected.

---

Context: the map rendering you took into 0.4.0 came from my widget, this continues that
work. I have been running this change on my own X40 Ultra since building it.

This PR is independent of my other one (menu width / settings rows) — they touch different
files and can be merged in any order, or separately.

Happy to adjust anything: naming, where the editor lives, or the wording of the UI strings.

<img width="1533" height="827" alt="Zwischenablage01" src="https://github.com/user-attachments/assets/491793e0-83c9-4e50-878c-3a4d31ea30a7" />
<img width="1534" height="834" alt="Zwischenablage02" src="https://github.com/user-attachments/assets/2979f802-7a9e-4b42-9fe5-8ded4417af29" />

