### PR TITLE
Widget: menu width as a number field, and fix the label association in the settings rows

### DIFF
--- a/www/css/layout.css
+++ b/www/css/layout.css
@@ -238,7 +238,11 @@ input[type="color"]{width:36px; height:28px; padding:2px; border-radius:6px;
   text-align:right; -moz-appearance:textfield; appearance:textfield}
 .zovl-zoom input[type=number]::-webkit-outer-spin-button,
 .zovl-zoom input[type=number]::-webkit-inner-spin-button{-webkit-appearance:none; margin:0}
-.zovl-zoom-pct{font-size:12px; color:var(--muted); margin-right:2px}
+/* Feste Mindestbreite fuer die Einheit: "%" ist schmaler als "px", ohne sie saessen die
+   Plus-Knoepfe von UI-Zoom und Menue-Breite nicht untereinander. Links ausgerichtet, damit
+   die Einheit direkt am Zahlenfeld klebt und nur rechts davon Luft entsteht. */
+.zovl-zoom-pct{font-size:12px; color:var(--muted); margin-right:2px;
+  display:inline-block; min-width:15px; text-align:left}
 .zovl-zoom button{width:26px; height:26px; border-radius:7px; border:1px solid var(--line);
   background:var(--panel2); color:var(--txt); font-size:14px; line-height:1; cursor:pointer; flex:none}
 .zovl-zoom button:hover{border-color:var(--accent,#4a78e0)}

--- a/www/css/layout.css
+++ b/www/css/layout.css
@@ -243,12 +243,11 @@ input[type="color"]{width:36px; height:28px; padding:2px; border-radius:6px;
   background:var(--panel2); color:var(--txt); font-size:14px; line-height:1; cursor:pointer; flex:none}
 .zovl-zoom button:hover{border-color:var(--accent,#4a78e0)}
 .zovl-zoom button:active{transform:scale(.93)}
-.zovl-wert{color:var(--muted); font-weight:400}
-/* Menue-Breite (Etappe E2c, Nachtrag 3): generische input[type=range]-Optik weiter unten
-   in dieser Datei ist width:100% (fuers Reinigungs-Panel gedacht) -- in der schmalen 320px-
-   Spalte hier neben einem Label wuerde das den Platz sprengen, gleiches Prinzip wie beim
-   inzwischen entfernten UI-Zoom-Slider. */
-.zovl-feld input[type=range]{width:140px; flex:none}
+/* .zovl-wert und .zovl-feld input[type=range] sind hier entfallen: das einzige verbliebene
+   Overlay-Feld mit Schieberegler (Menue-Breite) ist jetzt ebenfalls ein Zahlenfeld mit
+   Minus/Plus, wie zuvor schon der UI-Zoom -- damit gibt es im Overlay keinen Regler mehr,
+   dessen Breite begrenzt und keinen Wert, der neben dem Label angezeigt werden muesste
+   (der Wert steht im Feld). Begruendung des Umbaus: main.js bei wendeUndSchreibeBreite. */
 
 /* Link-Sektion (Etappe E2e): Button oben ueber die volle Sektionsbreite, darunter das
    readonly-Textfeld, darunter eine Zeile mit Checkbox links / Kopieren-Button rechts. Kein

--- a/www/index.html
+++ b/www/index.html
@@ -81,8 +81,14 @@
                 <button type="button" id="zovlGroessePlus" aria-label="Vergrößern">+</button>
               </span>
             </label>
-            <label class="zovl-feld"><span>Menü-Breite <span class="zovl-wert" id="zovlBreiteWert"></span></span>
-              <input type="range" id="zovlBreite" min="250" max="500" step="10">
+            <!-- Zahlenfeld statt Schieberegler, gleiches Muster wie der UI-Zoom darueber
+                 (Begruendung siehe main.js bei wendeUndSchreibeBreite). -->
+            <label class="zovl-feld"><span>Menü-Breite</span>
+              <span class="zovl-zoom">
+                <button type="button" id="zovlBreiteMinus" aria-label="Schmaler">−</button>
+                <input type="number" id="zovlBreite" min="250" max="500" step="5"><span class="zovl-zoom-pct">px</span>
+                <button type="button" id="zovlBreitePlus" aria-label="Breiter">+</button>
+              </span>
             </label>
           </section>
           <section class="zovl-sektion" id="zovlPanels">

--- a/www/index.html
+++ b/www/index.html
@@ -74,7 +74,13 @@
                 <span class="zovl-switch-txt" id="zovlLeisteTxt">Rechts</span>
               </span>
             </label>
-            <label class="zovl-feld"><span>UI-Zoom</span>
+            <!-- for="zovlGroesse" ist PFLICHT, nicht Kosmetik: ohne das Attribut gilt das
+                 erste bedienbare Element im <label> als sein Bedienelement -- und das ist hier
+                 der Minus-Knopf, nicht das Zahlenfeld. Folge waere (live nachgestellt): ein
+                 Klick auf die Beschriftung, auf "%" oder ins Leere der Zeile drueckt Minus,
+                 und beim Zeigen auf irgendeinen Teil der Zeile spiegelt der Browser :hover
+                 zusaetzlich auf den Minus-Knopf, der dadurch mit aufleuchtet. -->
+            <label class="zovl-feld" for="zovlGroesse"><span>UI-Zoom</span>
               <span class="zovl-zoom">
                 <button type="button" id="zovlGroesseMinus" aria-label="Verkleinern">−</button>
                 <input type="number" id="zovlGroesse" min="70" max="150" step="5"><span class="zovl-zoom-pct">%</span>
@@ -82,8 +88,9 @@
               </span>
             </label>
             <!-- Zahlenfeld statt Schieberegler, gleiches Muster wie der UI-Zoom darueber
-                 (Begruendung siehe main.js bei wendeUndSchreibeBreite). -->
-            <label class="zovl-feld"><span>Menü-Breite</span>
+                 (Begruendung siehe main.js bei wendeUndSchreibeBreite) -- einschliesslich des
+                 dort erklaerten for-Attributs. -->
+            <label class="zovl-feld" for="zovlBreite"><span>Menü-Breite</span>
               <span class="zovl-zoom">
                 <button type="button" id="zovlBreiteMinus" aria-label="Schmaler">−</button>
                 <input type="number" id="zovlBreite" min="250" max="500" step="5"><span class="zovl-zoom-pct">px</span>

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -268,7 +268,6 @@ function initAussehenSektion(config) {
   const breite = L.width || 275;
   document.documentElement.style.setProperty('--leiste-breite', breite + 'px');
   document.getElementById('zovlBreite').value = breite;
-  fuelleBreite();
 }
 
 document.getElementById('zovlTheme').onchange = e => {
@@ -322,21 +321,29 @@ document.getElementById('zovlGroessePlus').onclick = () => wendeUndSchreibeGroes
 // Menue-Breite (Etappe E2c, Nachtrag 3): nutzt das seit E2a im Schema stehende, bisher nie
 // verdrahtete config.widget.layout.width + die zugehoerige --leiste-breite-CSS-Variable
 // (.side{width:calc(var(--leiste-breite) * var(--ui))}, siehe layout.css) -- bewusst kein
-// neues Feld, David-Entscheidung. input (Ziehen): nur live anwenden + Fuellstand/Anzeige
-// aktualisieren, kein Schreiben. change (Loslassen): persistieren -- gleiches Muster wie
-// der Wetness-Slider in reinigung.js.
+// neues Feld, David-Entscheidung.
+//
+// Zahlenfeld + Minus/Plus statt Schieberegler -- gleiches Muster wie der UI-Zoom darueber,
+// und aus demselben Grund. Der Regler war hier naemlich kaum bedienbar: Das
+// Einstellungs-Overlay haengt am Rand des Kartenbereichs (.zovl{right:var(--conn-rand)},
+// bei linker Leiste spiegelbildlich left:var(--umschalter-rand)). Wird die Leiste breiter,
+// wird der Kartenbereich schmaler -- das Overlay wandert also samt Regler zur Seite,
+// WAEHREND man ihn zieht (live gemessen: 250 px Versatz ueber den Reglerbereich, bei nur
+// 140 px Reglerbreite, in beiden Leistenlagen spiegelbildlich). Der Schiebeknopf lief
+// dadurch unter dem Zeiger weg. Mit Zahlenfeld/Tasten gibt es kein Ziehen mehr, und pro
+// Klick verschiebt sich das Overlay nur um die Schrittweite.
+// Schrittweite 5 statt 10, weil man mit 10er-Schritten die passende Breite oft nicht trifft.
 const zovlBreiteEl = document.getElementById('zovlBreite');
-const zovlBreiteWertEl = document.getElementById('zovlBreiteWert');
-function fuelleBreite() {
-  const pct = (Number(zovlBreiteEl.value) - Number(zovlBreiteEl.min)) / (Number(zovlBreiteEl.max) - Number(zovlBreiteEl.min)) * 100;
-  zovlBreiteEl.style.setProperty('--fill', pct + '%');
-  zovlBreiteWertEl.textContent = zovlBreiteEl.value + ' px';
+function wendeUndSchreibeBreite(px) {
+  const geklemmt = Math.min(500, Math.max(250, Math.round(px) || 275)); // wie beim Zoom:
+  // HTML5 min/max greift meist selbst, das Klemmen hier faengt "abc"/leer/Tippfehler ab
+  zovlBreiteEl.value = geklemmt;
+  document.documentElement.style.setProperty('--leiste-breite', geklemmt + 'px');
+  schreibeLayout('width', geklemmt);
 }
-zovlBreiteEl.oninput = () => {
-  document.documentElement.style.setProperty('--leiste-breite', zovlBreiteEl.value + 'px');
-  fuelleBreite();
-};
-zovlBreiteEl.onchange = () => schreibeLayout('width', Number(zovlBreiteEl.value));
+zovlBreiteEl.onchange = () => wendeUndSchreibeBreite(Number(zovlBreiteEl.value));
+document.getElementById('zovlBreiteMinus').onclick = () => wendeUndSchreibeBreite(Number(zovlBreiteEl.value) - 5);
+document.getElementById('zovlBreitePlus').onclick = () => wendeUndSchreibeBreite(Number(zovlBreiteEl.value) + 5);
 
 // ===== Panels-Sektion im Einstellungs-Overlay (Etappe E2d): Sichtbarkeit-Toggle pro Panel
 // (Ebene 1 aus WIDGET_UMBAU_PLAN.md Abschnitt 8.2 -- Feld-Sichtbarkeit "versteckt" ist


### PR DESCRIPTION
## Problem 1 — the menu width slider ran away while dragging it

The settings overlay is anchored to the edge of the map area
(`.zovl{right:var(--conn-rand)}`, mirrored to `left:var(--umschalter-rand)` for a left-hand
sidebar). Making the sidebar wider makes the map area narrower, so **the overlay — and the
slider inside it — moves sideways**. Because the width is applied live on `input`, this
happens *during* the drag: the thumb slides out from under the pointer.

Measured in the browser: across the slider's range (250–500 px) the overlay shifts by
**250 px**, while the slider itself is only 140 px wide. Same in both sidebar positions,
mirrored.

## Problem 2 — clicking a row's label pressed its minus button

Both number rows in the overlay (UI zoom, menu width) are a `<label>` without a `for`
attribute. The labeled control is then the **first labelable descendant**, which is the
minus button, not the number input (`label.control === "zovlGroesseMinus"`, reproduced in
the browser).

Two consequences, both confirmed:

* Clicking the caption, the unit, or empty space in the row **triggered the minus button** —
  clicking the text "UI-Zoom" decreased the value. You could change a setting without ever
  hitting a button.
* Browsers mirror `:hover` from a label onto its labeled control, so the minus button lit up
  whenever the pointer was anywhere in the row. Moving between the two rows looked as if
  minus *and* plus were suddenly highlighted.

This one is pre-existing and affects the UI zoom control; the new width field would only
have duplicated it.

## Changes

* **Menu width is now a number field with − / +**, the same pattern the UI zoom above
  already uses — introduced there for the same reason (see the comment at
  `wendeUndSchreibeGroesse`). No dragging, so nothing can run away: per click the overlay
  shifts by one step only (measured 5 px, at 26 px button width, so the button stays under
  the pointer). The width can also be typed in directly.
  Step 5 instead of 10 — with 10 px steps the desired width is often not reachable. Range
  (250–500) unchanged.
* **`for="zovlGroesse"` / `for="zovlBreite"`** on the two labels. An explicit association
  beats the implicit "first labelable descendant", so the label points at the number input
  again: clicking the caption just focuses the field, and `:hover` is mirrored onto the
  input (no visible effect, there is no hover rule for it).
* **Unit label gets a fixed min-width.** "%" is narrower than "px"; since the group is
  right-aligned the plus buttons already lined up, but the minus button and the number field
  of the width row sat 3 px further left. Now 0 px offset on all three.

With the width slider gone, the overlay has no `input[type=range]` left — the rules that
existed only for it (`.zovl-wert`, `.zovl-feld input[type=range]`) are removed.

## How to test

1. Open the settings, change **Menü-Breite** with − / + or by typing — the sidebar resizes
   and the buttons stay put under the pointer.
2. Click the caption "UI-Zoom" or the "%" next to the number: nothing changes any more
   (before: the value decreased).
3. Hover the plus button of either row: only that button gets the accent border.

---

Context: the map rendering you took into 0.4.0 came from my widget, this continues that
work. I have been running this change on my own X40 Ultra since building it.

This PR is independent of my other one (per-room cleanset editor) — they touch different
files and can be merged in any order, or separately.

Happy to adjust anything, in particular if you would rather keep the slider: the same
result can be had by compensating the overlay's shift while dragging, it just needs more
code than reusing the number-field pattern you already established for the zoom.